### PR TITLE
Changed WordPress version to 5.1.1 from 5.2.2 due to PHP versioning

### DIFF
--- a/Security/200_Automated_Deployment_of_EC2_Web_Application/Code/wordpress.yaml
+++ b/Security/200_Automated_Deployment_of_EC2_Web_Application/Code/wordpress.yaml
@@ -298,7 +298,7 @@ Resources:
               php: []
               php-mysql: []
           sources:
-            /var/www/html: 'https://wordpress.org/latest.tar.gz'
+            /var/www/html: 'https://wordpress.org/wordpress-5.1.1.tar.gz'
           files:
             /tmp/create-wp-config:
               content: !Sub |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed WordPress version to 5.1.1. 5.2.2 required PHP5.6+ which isn't available on Amazon Linux 2 at present


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
