### PR TITLE
Fix typo in docs for Level 100 walkthrough

### DIFF
--- a/Well-ArchitectedTool/100_Walkthrough_of_the_Well-Architected_Tool/README.md
+++ b/Well-ArchitectedTool/100_Walkthrough_of_the_Well-Architected_Tool/README.md
@@ -16,7 +16,7 @@ The knowledge you acquire will help you build Well-Architected workloads in alig
 ## Prequisites:
 
 * An 
-[AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for tesintg, that is not used for production or other purposes.
+[AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for testing, that is not used for production or other purposes.
 * An Identity and Access Management (IAM) user or federated credentials into that account that has permissions to usee Well-Architected Tool (WellArchitectedConsoleFullAccess managed policy).
 
 


### PR DESCRIPTION
*Issue #, if available:*
Typo in the docs for 100 walkthrough: "tesintg" instead of "testing"
*Description of changes:*
Fix the typo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
