### PR TITLE
Pr22 addendum - remove colons form all other READMEs

### DIFF
--- a/Operations/README.md
+++ b/Operations/README.md
@@ -7,7 +7,7 @@ This repository contains documentation and code in the format of hands-on labs t
 
 For more information about Operational Excellence on AWS visit the Well-Architected tool in the AWS console, and read the AWS [Well-Architected Operational Excellence](https://d1.awsstatic.com/whitepapers/architecture/AWS-Operational-Excellence-Pillar.pdf) whitepaper.
 
-## Labs:
+## Labs
 
 ### Operations Fundamentals
 - [Level 100: Introduction to Inventory and Patch Management](100_Inventory_and_Patch_Mgmt/README.md)

--- a/Reliability/README.md
+++ b/Reliability/README.md
@@ -8,7 +8,7 @@ This repository contains documentation and code in the format of hands-on-labs t
 For more information about Reliability, read the 
 [AWS Well-Architected Reliability whitepaper](https://d1.awsstatic.com/whitepapers/architecture/AWS-Reliability-Pillar.pdf).
 
-## Labs:
+## Labs
 - [Level 200: Testing for Resiliency of EC2](200_Testing_for_Resiliency_of_EC2/README.md) 
 - [Level 300: Testing for Resiliency of EC2, RDS, and S3](300_Testing_for_Resiliency_of_EC2_RDS_and_S3/README.md) 
 

--- a/Well-ArchitectedTool/100_Walkthrough_of_the_Well-Architected_Tool/README.md
+++ b/Well-ArchitectedTool/100_Walkthrough_of_the_Well-Architected_Tool/README.md
@@ -16,7 +16,7 @@ The knowledge you acquire will help you build Well-Architected workloads in alig
 ## Prequisites:
 
 * An 
-[AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for tesintg, that is not used for production or other purposes.
+[AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for testing, that is not used for production or other purposes.
 * An Identity and Access Management (IAM) user or federated credentials into that account that has permissions to usee Well-Architected Tool (WellArchitectedConsoleFullAccess managed policy).
 
 

--- a/Well-ArchitectedTool/README.md
+++ b/Well-ArchitectedTool/README.md
@@ -8,7 +8,7 @@ This repository contains documentation and code in the format of hands-on-labs t
 For more information about the Well-Architected tool, read the 
 [AWS Well-Architected Tool documentation](https://docs.aws.amazon.com/wellarchitected/latest/userguide/intro.html).
 
-## Labs:
+## Labs
 
 - [Level 100: Walkthrough of the AWS Well-Architected Tool](100_Walkthrough_of_the_Well-Architected_Tool/README.md) 
 


### PR DESCRIPTION
*Issue #, if available:*

In https://github.com/awslabs/aws-well-architected-labs/pull/22 colons were removed from README for Security.   This change also removes them from the other labs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
