### PR TITLE
SEC300LambdaCrossAccount: improve Lambda output; add clarifications; …

### DIFF
--- a/Security/300_Lambda_Cross_Account_IAM_Role_Assumption/Lab_Guide.md
+++ b/Security/300_Lambda_Cross_Account_IAM_Role_Assumption/Lab_Guide.md
@@ -23,22 +23,22 @@
 8. Copy the Role ARN and store for use later in this lab.
 9. Click Add inline policy, then click JSON tab.
 10. Replace the sample json with the following, then click Review Policy.
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
+
         {
-            "Sid": "S3ListAllMyBuckets",
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListAllMyBuckets"
-            ],
-            "Resource": "*"
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "S3ListAllMyBuckets",
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:ListAllMyBuckets"
+                    ],
+                    "Resource": "*"
+                }
+            ]
         }
-    ]
-}
-```
-11. Name this policy LambdaS3ListBuckets, then click Create policy.
+
+11. Name this policy LambdaS3ListBucketsPolicy, then click Create policy.
 
 ## 2. Create role for Lambda in account 1 <a name="create_role_1"></a>
 
@@ -51,41 +51,41 @@
 7. From the list of roles click the name of Lambda-Assume-Roles.
 8. Copy the Role ARN and store for use later in this lab.
 9. Click Add inline policy, then click JSON tab.
-10. Replace the sample json with the following, replacing account1 and account2 with your respective account id's, us-east-1 region with the region you are using, then click Review Policy.
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
+10. Replace the sample json with the following, replacing **account1** and **account2** with your respective account id's, us-east-1 region with the region you are using, then click Review Policy.
+
         {
-            "Sid": "stsassumerole",
-            "Effect": "Allow",
-            "Action": "sts:AssumeRole",
-            "Resource": "arn:aws:iam::account2:role/LambdaS3ListBuckets",
-            "Condition": {
-                "StringLike": {
-                    "aws:UserAgent": "*AWS_Lambda_python*"
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "stsassumerole",
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": "arn:aws:iam::account2:role/LambdaS3ListBuckets",
+                    "Condition": {
+                        "StringLike": {
+                            "aws:UserAgent": "*AWS_Lambda_python*"
+                        }
+                    }
+                },
+                {
+                    "Sid": "logsstreamevent",
+                    "Effect": "Allow",
+                    "Action": [
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                    ],
+                    "Resource": "arn:aws:logs:us-east-1:account1:log-group:/aws/lambda/Lambda-Assume-Roles*/*"
+                },
+                {
+                    "Sid": "logsgroup",
+                    "Effect": "Allow",
+                    "Action": "logs:CreateLogGroup",
+                    "Resource": "*"
                 }
-            }
-        },
-        {
-            "Sid": "logsstreamevent",
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents"
-            ],
-            "Resource": "arn:aws:logs:us-east-1:account1:log-group:/aws/lambda/Lambda-Assume-Roles*/*"
-        },
-        {
-            "Sid": "logsgroup",
-            "Effect": "Allow",
-            "Action": "logs:CreateLogGroup",
-            "Resource": "*"
+            ]
         }
-    ]
-}
-```
-11. Name this policy Lambda-Assume-Roles, then click Create policy.
+
+11. Name this policy Lambda-Assume-Roles-Policy, then click Create policy.
 
 ***
 
@@ -98,28 +98,28 @@
 5. Select Python 3.6 runtime.
 6. Expand Permissions, click Use an existing role, then select the Lambda-Assume-Roles role.
 7. Click Create function.
-8. Replace the example function code with the following, replacing the RoleArn with the one from account 2 you created previously.
+8. Replace the example function code with the following, replacing the **RoleArn** with the one from account 2 you created previously.
 
-```
-import json
-import boto3
-import os
-import uuid
+        import json
+        import boto3
+        import os
+        import uuid
 
-def lambda_handler(event, context):
-    try:
-        client = boto3.client('sts')
-        response = client.assume_role(RoleArn='arn:aws:iam::account2:role/LambdaS3ListBuckets',RoleSessionName="{}-s3".format(str(uuid.uuid4())[:5]))
-        session = boto3.Session(aws_access_key_id=response['Credentials']['AccessKeyId'],aws_secret_access_key=response['Credentials']['SecretAccessKey'],aws_session_token=response['Credentials']['SessionToken'])
+        def lambda_handler(event, context):
+            try:
+                client = boto3.client('sts')
+                response = client.assume_role(RoleArn='arn:aws:iam::account2:role/LambdaS3ListBuckets',RoleSessionName="{}-s3".format(str(uuid.uuid4())[:5]))
+                session = boto3.Session(aws_access_key_id=response['Credentials']['AccessKeyId'],aws_secret_access_key=response['Credentials']['SecretAccessKey'],aws_session_token=response['Credentials']['SessionToken'])
 
-        s3 = session.client('s3')
-        s3list = s3.list_buckets()
-        print (s3list)
+                s3 = session.client('s3')
+                s3list = s3.list_buckets()
+                print (s3list)
+                return str(s3list['Buckets'])
 
-    except Exception as e:
-        print(e)
-        raise e
-```
+            except Exception as e:
+                print(e)
+                raise e
+
 9. Click Save.
 10. Click Test, accept the default event template, enter event name of test, then click Create.
 11. Click Test again, and in a few seconds the function output should highlight green and you can expand the detail to see the response from the S3 API.
@@ -136,8 +136,7 @@ Remove the lambda function, then roles.
 
 ## References & useful resources
 
-https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html
-https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html
+<https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html>
 
 ***
 
@@ -152,5 +151,3 @@ Licensed under the Apache License, Version 2.0 (the "License"). You may not use 
     https://aws.amazon.com/apache2.0/
 
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
-


### PR DESCRIPTION
…MD linting to fix step numbering

*Issue #, if available:*

*Description of changes:*
* Add bucket output from Lambda so shows up in _result returned by your function_ and not just in _Log Output_
* Clarify where to make replacements in policies and code
* distinguish policy names from role names
* MarkDown linting - this will fix the problem on the website where step numbering restarts after code

I originally had the content change separate from the linting but it got combined (sorry).  Note for bucket output, this was added to the Lambda code.  If you want to see [JUST the content changes, look here](https://github.com/setheliot/aws-well-architected-labs/commit/164ff318fc413b0bd1970d54d7c74ea84d0af427)

```
                return str(s3list['Buckets'])
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
