### PR TITLE
Fix instructions to use upload template

### DIFF
--- a/Operations/100_Inventory_and_Patch_Mgmt/Lab_Guide.md
+++ b/Operations/100_Inventory_and_Patch_Mgmt/Lab_Guide.md
@@ -114,7 +114,7 @@ To deploy the lab infrastructure:
 1. **Download the CloudFormation script** for this lab from [/Code](https://github.com/awslabs/aws-well-architected-labs/blob/master/Operations/100_Inventory_and_Patch_Mgmt/Code).
 1. Use your administrator account to access the CloudFormation console at <https://console.aws.amazon.com/cloudformation/>.
 1. Choose **Create Stack**.
-1. On the **Select Template** page, select **Specify an Amazon S3 template URL** and enter the URL for the downloaded location.
+1. On the **Select Template** page, select **Upload a template file** and select `OE_Inventory_and_Patch_Mgmt.json` file you had just downloaded.
 
 **AWS CloudFormation Designer**
 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

The instructions for deploying CloudFormation template asks to download a .json file but later to use an Amazon S3 URL. The correct path would be to use _Upload a template file_ instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
