### PR TITLE
Fixes broken template (capitalisation of the NamingPrefix value leads to rollback)

### DIFF
--- a/Security/200_Automated_Deployment_of_EC2_Web_Application/Code/wordpress.yaml
+++ b/Security/200_Automated_Deployment_of_EC2_Web_Application/Code/wordpress.yaml
@@ -22,7 +22,7 @@ Parameters:
   NamingPrefix:
     Type: String
     Description: The naming prefix for resources created by this template.
-    Default: WebApp1
+    Default: webapp1
   #Imports:
   VPCImportName:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current template won't build. It will fail to build DB1Cluster and then do a rollback because it cannot find "WebApp1-dbsubnetgroupwp".

The reason for this seems to be that (despite the capitalisation in the parameter) DB1SubnetGroup gets created with an all lower case DBSubnetGroupName. This issue has been mentioned in a few places, e.g.: https://forums.aws.amazon.com/thread.jspa?threadID=280574 and  https://www.reddit.com/r/aws/comments/8v8dmj/workaround_for_cloudformations_inability_to_find/

This PR fixes the Lab template by simply changing NamingPrefix default value to be all lower case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
