### PR TITLE
SEC200-VPC change Flow Logs Log Group to a dynamically created name

### DIFF
--- a/Security/200_Automated_Deployment_of_VPC/Code/vpc-alb-app-db.yaml
+++ b/Security/200_Automated_Deployment_of_VPC/Code/vpc-alb-app-db.yaml
@@ -228,7 +228,6 @@ Resources:
     Type: "AWS::Logs::LogGroup"
     DeletionPolicy: Delete
     Properties:
-      LogGroupName: !Sub '${NamingPrefix}-VPCFlowLog'
       RetentionInDays: !Ref VPCFlowLogRetention
   VPCFlowLog:
     #https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html
@@ -238,7 +237,7 @@ Resources:
       DeliverLogsPermissionArn: !GetAtt VPCFlowLogRole.Arn
       #LogDestination
       LogDestinationType: cloud-watch-logs
-      LogGroupName: !Sub '${NamingPrefix}-VPCFlowLog'
+      LogGroupName: !Ref VPCFlowLogGroup
       ResourceId: !Ref VPC
       ResourceType: VPC
       TrafficType: ALL

--- a/Security/200_Automated_Deployment_of_VPC/Lab_Guide.md
+++ b/Security/200_Automated_Deployment_of_VPC/Lab_Guide.md
@@ -74,7 +74,7 @@ Delete the CloudWatch Logs:
 
 1. Sign in to the AWS Management Console, select your preferred region, and open the CloudFormation console at [https://console.aws.amazon.com/cloudwatch/](https://console.aws.amazon.com/cloudwatch/).
 2. Click **Logs** in the left navigation.
-3. Click the radio button on the left of the **WebApp1-VPCFlowLog**.
+3. Click the radio button on the left of the **WebApp1-VPC-VPCFlowLogGroup-\<some unique ID\>**.
 4. Click the **Actions Button** then click **Delete Log Group**.
 5. Verify the log group name then click **Yes, Delete**.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* This avoids the problem where a stack create - delete - create will fail because the VPC Flow Logs with that name already exists

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
