### PR TITLE
Change a tags colour from grey to indigo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ docs/
 .pyc
 dist/
 .vscode/
+
+# https://github.com/awslabs/aws-well-architected-labs/issues/92
+!docs/stylesheets/

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,4 @@
+/* https://github.com/awslabs/aws-well-architected-labs/issues/92 */
+article a {
+    color: #3f51b5 !important
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,9 @@ theme:
         accent: 'grey' 
     logo: 'images/wa.png' 
 
+# https://github.com/awslabs/aws-well-architected-labs/issues/92
+extra_css:
+  - 'stylesheets/extra.css'
 
 nav:
     - Home: README.md 


### PR DESCRIPTION
*Issue #, if available:* #92 

**Description of changes**: As per @setheliot request, this changes the color of hyperlinks within the content section (not the menus).

**Changes**

* [x] Add `docs/stylesheet` as an exception to `gitignore`
* [x] Add `extra.css`
* [x] Override a tags colour from `grey` to `#3f51b5`

**How did I test**

* Move content to `docs`, and run site locally via docker: `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/
mkdocs-material`
* Also changed live WA Labs site CSS on the fly to double check it works

**Before**
![image](https://user-images.githubusercontent.com/3340292/75542762-56c9c480-5a18-11ea-801a-1aed2a5b94a9.png)

**After**
![image](https://user-images.githubusercontent.com/3340292/75542768-59c4b500-5a18-11ea-9475-758ee725c536.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
