### PR TITLE
Updating the main color of the links to Amazon Orange-Yellow

### DIFF
--- a/static/css/theme-walabs.css
+++ b/static/css/theme-walabs.css
@@ -3,8 +3,8 @@
 
     --MAIN-TEXT-color:#232F3E; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #161E2D; /* Color of titles h2-h3-h4-h5 */
-    --MAIN-LINK-color:#95b0ff; /* Color of links */
-    --MAIN-LINK-HOVER-color:#527FFF; /* Color of hovered links */
+    --MAIN-LINK-color:#FF9900; /* Color of links */
+    --MAIN-LINK-HOVER-color:#FFA319; /* Color of hovered links */
     --MAIN-ANCHOR-color: #95b0ff; /* color of anchors on titles */
 
     --MENU-HEADER-BG-color:#161E2D; /* Background color of menu header */


### PR DESCRIPTION
*Issue #, if available:* #109 

*Description of changes:*
- [x] Changed the css variable --MAIN-LINK-color to Amazon Orange-Yellow
- [x] Changed the css variable --MAIN-LINK-HOVER-color to #ffa319 which is Orange-Yellow with 10% decrease on saturation.

## Before
![Before](https://i.imgur.com/FyYYHZL.png)

## After
![After](https://i.imgur.com/ICpHswF.png)


This also closes #109

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
