### PR TITLE
Using CSS to handle logo width in different resolutions

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,3 +1,3 @@
 <a id="logo" href="{{ .Site.BaseURL }}">
-  <img src="/images/wa.png" width="200" alt="Well-Architected Labs">
+  <img src="/images/wa.png" alt="Well-Architected Labs">
 </a>

--- a/static/css/theme-walabs.css
+++ b/static/css/theme-walabs.css
@@ -3,8 +3,8 @@
 
     --MAIN-TEXT-color:#232F3E; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #161E2D; /* Color of titles h2-h3-h4-h5 */
-    --MAIN-LINK-color:#95b0ff; /* Color of links */
-    --MAIN-LINK-HOVER-color:#527FFF; /* Color of hovered links */
+    --MAIN-LINK-color:#FF9900; /* Color of links */
+    --MAIN-LINK-HOVER-color:#FFA319; /* Color of hovered links */
     --MAIN-ANCHOR-color: #95b0ff; /* color of anchors on titles */
 
     --MENU-HEADER-BG-color:#161E2D; /* Background color of menu header */

--- a/static/css/theme-walabs.css
+++ b/static/css/theme-walabs.css
@@ -263,3 +263,13 @@ div.cards.workshop div.content {
     padding: 0px;
     color: #333;
 }
+
+a#logo {
+    width: 200px;
+}
+
+@media all and (max-width: 480px) {
+    a#logo {
+      width: 96px;
+    }
+}

--- a/static/css/theme-walabs.css
+++ b/static/css/theme-walabs.css
@@ -3,8 +3,8 @@
 
     --MAIN-TEXT-color:#232F3E; /* Color of text by default */
     --MAIN-TITLES-TEXT-color: #161E2D; /* Color of titles h2-h3-h4-h5 */
-    --MAIN-LINK-color:#FF9900; /* Color of links */
-    --MAIN-LINK-HOVER-color:#FFA319; /* Color of hovered links */
+    --MAIN-LINK-color:#95b0ff; /* Color of links */
+    --MAIN-LINK-HOVER-color:#527FFF; /* Color of hovered links */
     --MAIN-ANCHOR-color: #95b0ff; /* color of anchors on titles */
 
     --MENU-HEADER-BG-color:#161E2D; /* Background color of menu header */


### PR DESCRIPTION
*Issue #, if available:* #108

*Description of changes:*

- [x] Remove the width attribute from  `layouts/partials/logo.html`
- [x] Added the default `200px` to `a#logo` following the original sizing
- [x] Added media query to handle devices with less than 480px to use `96px` as the new width

## before
![](https://i.imgur.com/eecpzO2.png)

## after on mobile
![](https://i.imgur.com/XvsE3zM.png)

## after on desktop
![](https://i.imgur.com/b9egDVq.png)


This fix and closes #108

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
