### PR TITLE
Found that the name of the dashboard id had a typo

### DIFF
--- a/content/Cost/200_Labs/200_Enterprise_Dashboards/1_create_cost_intelligence.md
+++ b/content/Cost/200_Labs/200_Enterprise_Dashboards/1_create_cost_intelligence.md
@@ -232,7 +232,7 @@ We will now use the CLI to create the dashboard from the Cost Intelligence Dashb
 
 Edit and run the following command:
 
-        aws quicksight describe-dashboard --aws-account-id (YOUR ACCOUNT ID) --dashboard-id cost__intelligence_dashboard --region (region)
+        aws quicksight describe-dashboard --aws-account-id (YOUR ACCOUNT ID) --dashboard-id cost_intelligence_dashboard --region (region)
 
 Correct the listed errors and run the **delete-dashboard** command followed by the original **create-dashboard** command:
 		


### PR DESCRIPTION
When trying the `aws quicksight describe-dashboard` command i did notice a typo with double underscore "__"

