### PR TITLE
Modifying warning language for PERF clock source lab to make it clear…

### DIFF
--- a/content/Performance Efficiency/100_Labs/100_Clock_Source_Performance/1_deploy.md
+++ b/content/Performance Efficiency/100_Labs/100_Clock_Source_Performance/1_deploy.md
@@ -14,7 +14,7 @@ The CloudFormation template that accompanies this lab requires the ability to cr
 
 1. Download the [time_test.yaml](/Performance/100_Clock_Source_Performance/Code/time_test.yaml) CloudFormation template to your machine.
 1. This lab assumes you will be deploying to the default VPC within your AWS account.  If you wish to deploy to a different VPC, just select the subnet that corresponds to your VPC. {{% notice warning %}}
-If you have modified the default VPC or are using a VPC you have created, ensure that the subnet you are deploying the EC2 instances into can communicate with AWS Systems Manager. One method for this is to [Create a VPC endpoint for SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html)
+If you have modified the default VPC or are using a VPC you have created, ensure that the subnet you are deploying the EC2 instances into can communicate with the internet and with AWS Systems Manager. One method for this is to [Create a VPC endpoint for SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html)
 {{% /notice %}}
 
 


### PR DESCRIPTION
Minor wording change to warning message to ensure it is clear you will need internet access to perform this lab. 