### PR TITLE
changed  describe-db-instance command to use query option instead of jq

### DIFF
--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/bash/failover_rds.sh
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/bash/failover_rds.sh
@@ -23,8 +23,12 @@ fi
 
 #Find the first running rds instance in the list that is in the VPC and return it's instance ID.
 #Note: This is making a lot of assumptions. A lot more error checking could be done
-rds_instance_id=`aws rds describe-db-instances | jq -r --arg vpc $1 '.DBInstances | map(select(.DBSubnetGroup.VpcId==$vpc))[0].DBInstanceIdentifier'`
-echo "Failing over $rds_instance_id"
+rds_instance_id="$(aws rds describe-db-instances --query "[DBInstances[0]]|[?DBSubnetGroup.VpcId=='$1'].DBInstanceIdentifier" --output text)"
+if [ -z $rds_instance_id ]; then
+  echo "No RDS instance found in $0 vpc"
+  else
+    echo "Failing over $rds_instance_id"
+fi
 
 # Reboot with failover that instance
 aws rds reboot-db-instance --db-instance-identifier $rds_instance_id --force-failover


### PR DESCRIPTION
*Issue #79 

*Description of changes:*
Changed describe-db-instances command to use query option instead of JQ in order to get the db instance identifier


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
