### PR TITLE
Allow for a more resilient failure script

### DIFF
--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/bash/failover_rds.sh
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/bash/failover_rds.sh
@@ -23,7 +23,7 @@ fi
 
 #Find the only running rds instance in the list that is in the VPC and return it's instance ID.
 #Note: This is assuming there is only one RDS instance in the VPC.  Otherwise this script fails
-rds_instance_id="$(aws rds describe-db-instances --query "DBInstances[?DBSubnetGroup.VpcId=='$1'].DBInstanceIdentifier" --output text)"
+rds_instance_id="$(aws rds describe-db-instances --query "DBInstances[?DBSubnetGroup.VpcId=='$1' && MultiAZ].DBInstanceIdentifier" --output text)"
 
 if [ -z $rds_instance_id ]; then
     echo "No RDS instance found in $0 vpc"


### PR DESCRIPTION
Cloudformation for multi region creates a Primary and secondary DB instance in the VPC which confuses this script.  By looking for the instance which is deployed using MultiAZ the script returns a single instance ID.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
