### PR TITLE
Fix for issue #210

### DIFF
--- a/static/Operations/100_Dependency_Monitoring/Code/dependency_monitoring.yaml
+++ b/static/Operations/100_Dependency_Monitoring/Code/dependency_monitoring.yaml
@@ -19,6 +19,9 @@ Description: >-
   express or implied. See the License for the specific language governing
   permissions and limitations under the License.
 Parameters:
+  AvailabilityZone: 
+    Type: 'AWS::EC2::AvailabilityZone::Name'
+    Description: The Availability Zone in which resources are launched.
   BucketName:
     Type: String
     Description: >-
@@ -42,6 +45,7 @@ Resources:
   Subnet:
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AvailabilityZone: !Ref AvailabilityZone
       CidrBlock: 10.0.0.0/24
       VpcId: !Ref VPC
       MapPublicIpOnLaunch: 'true'


### PR DESCRIPTION
*Issue #, if available:* #210

*Description of changes:* Added Availability Zone as a parameter. If users run into Insufficient Instance Capacity issues when they deploy the CloudFormation stack, they can delete the stack and relaunch by choosing a different Availability Zone to avoid further Insufficient Instance Capacity issues.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
