### PR TITLE
Antross fixes

### DIFF
--- a/content/Reliability/100_Labs/100_Deploy_CloudFormation/_index.md
+++ b/content/Reliability/100_Labs/100_Deploy_CloudFormation/_index.md
@@ -36,7 +36,7 @@ By the end of this lab, you will be able to:
 
 ## Prequisites
 
-If you are running the at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
+If you are running this at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
 
 * An [AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for testing. This account MUST NOT be used for production or other purposes.
 * An Identity and Access Management (IAM) user or federated credentials into that account that has permissions to create IAM Roles, EC2 instances, S3 buckets, DynamoDb tables, VPCs, Subnets, and Internet Gateways

--- a/content/Reliability/200_Labs/200_Bidirectional_Replication_for_S3/_index.md
+++ b/content/Reliability/200_Labs/200_Bidirectional_Replication_for_S3/_index.md
@@ -32,7 +32,7 @@ By the end of this lab, you will be able to:
 
 ## Prequisites
 
-If you are running the at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
+If you are running this at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
 
 * An [AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for testing. This account MUST NOT be used for production or other purposes.
 * An Identity and Access Management (IAM) user or federated credentials into that account that has permissions to create IAM Polices and Roles, create S3 buckets and bucket policies, get and put objects into S3 buckets, and create and read CloudTrail trails and CloudWatch Log Groups.

--- a/content/Reliability/200_Labs/200_Deploy_and_Update_CloudFormation/_index.md
+++ b/content/Reliability/200_Labs/200_Deploy_and_Update_CloudFormation/_index.md
@@ -36,7 +36,7 @@ By the end of this lab, you will be able to:
 
 ## Prequisites
 
-If you are running the at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
+If you are running this at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
 
 * An [AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for testing. This account MUST NOT be used for production or other purposes.
 * An Identity and Access Management (IAM) user or federated credentials into that account that has permissions to create IAM Roles, EC2 instances, S3 buckets, VPCs, Subnets, and Internet Gateways

--- a/content/Reliability/300_Labs/300_Health_Checks_and_Dependencies/_index.md
+++ b/content/Reliability/300_Labs/300_Health_Checks_and_Dependencies/_index.md
@@ -38,7 +38,7 @@ After you have completed this lab, you will be able to:
 
 ## Prequisites
 
-If you are running the at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
+If you are running this at an AWS sponsored workshop then you may be provided with an AWS Account to use, in which case the following pre-requisites will be satisfied by the provided AWS account.  If you are running this using your own AWS Account, then please note the following prerequisites:
 
 * An [AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) that you are able to use for testing. This account MUST NOT be used for production or other purposes.
 * An Identity and Access Management (IAM) user or federated credentials into that account that has permissions to create Amazon Virtual Private Cloud(s) (VPCs), including subnets and route tables, Security Groups, Internet Gateways, NAT Gateways, Elastic IP Addresses, IAM Roles, instance profiles, AWS Auto Scaling launch configurations, Application Load Balancers, Auto Scaling Groups, DynamoDB tables, SSM Parameters, and EC2 instances.

--- a/content/Security/100_Labs/100_CloudFront_with_S3_Bucket_Origin/2_upload_file.md
+++ b/content/Security/100_Labs/100_CloudFront_with_S3_Bucket_Origin/2_upload_file.md
@@ -8,17 +8,15 @@ pre: "<b>2. </b>"
 
 1. Create a simple index.html file, you can create by coping the following text into your favourite text editor.
 ```
- <!DOCTYPE html>
+<!DOCTYPE html>
 <html>
-<head>
-<title>Example</title>
-</head>
-<body>
-
-<h1>Example Heading</h1>
-<p>Example paragraph.</p>
-
-</body>
+  <head>
+    <title>Example</title>
+  </head>
+  <body>
+    <h1>Example Heading</h1>
+    <p>Example paragraph.</p>
+  </body>
 </html>
 ```
 2. Open the Amazon S3 console at [https://console.aws.amazon.com/s3/](https://console.aws.amazon.com/s3/).


### PR DESCRIPTION
*Issue #, if available:* N/A

* Fix HTML Indentation
* Fix grammatical errors



Can anyone tell me if `Prequisites` is actually supposed to be `Prerequisites`? If so, I'm happy to update those.  [Example](https://www.wellarchitectedlabs.com/reliability/200_labs/200_bidirectional_replication_for_s3/).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
