### PR TITLE
Bonus Organization Tags: Add support for pagination when calling list tags

### DIFF
--- a/content/Cost/300_Labs/300_Organization_Data_CUR_Connection/6_Bonus_Org_Tags.md
+++ b/content/Cost/300_Labs/300_Organization_Data_CUR_Connection/6_Bonus_Org_Tags.md
@@ -38,7 +38,7 @@ To get the Organizations tags, we need to update the Lambda function to pull thi
        if isinstance(o, datetime.datetime):
           return o.__str__()
       
-       def list_tags(resource_id):
+       def list_tags(client, resource_id):
           tags = []
           paginator = client.get_paginator("list_tags_for_resource")
           response_iterator = paginator.paginate(ResourceId=resource_id)
@@ -75,7 +75,7 @@ To get the Organizations tags, we need to update the Lambda function to pull thi
                    for account in response["Accounts"]:
                       aid = account["Id"]                
                       if tags_check != '':
-                            tags_list = list_tags(aid) #gets the lists of tags for this account
+                            tags_list = list_tags(client, aid) #gets the lists of tags for this account
                             
                             for tag in os.environ.get("TAGS").split(","): #looking at tags in the enviroment variables split by a space
                                for org_tag in tags_list:

--- a/content/Cost/300_Labs/300_Organization_Data_CUR_Connection/6_Bonus_Org_Tags.md
+++ b/content/Cost/300_Labs/300_Organization_Data_CUR_Connection/6_Bonus_Org_Tags.md
@@ -42,7 +42,7 @@ To get the Organizations tags, we need to update the Lambda function to pull thi
           tags = []
           paginator = client.get_paginator("list_tags_for_resource")
           response_iterator = paginator.paginate(ResourceId=resource_id)
-          for response in response_iterator
+          for response in response_iterator:
              tags.extend(response['Tags'])
           return tags
 

--- a/content/Cost/300_Labs/300_Organization_Data_CUR_Connection/6_Bonus_Org_Tags.md
+++ b/content/Cost/300_Labs/300_Organization_Data_CUR_Connection/6_Bonus_Org_Tags.md
@@ -37,6 +37,14 @@ To get the Organizations tags, we need to update the Lambda function to pull thi
        def myconverter(o):
        if isinstance(o, datetime.datetime):
           return o.__str__()
+      
+       def list_tags(resource_id):
+          tags = []
+          paginator = client.get_paginator("list_tags_for_resource")
+          response_iterator = paginator.paginate(ResourceId=resource_id)
+          for response in response_iterator
+             tags.extend(response['Tags'])
+          return tags
 
        def list_accounts():
           bucket = os.environ["BUCKET_NAME"] #Using enviroment varibles below the lambda will use your S3 bucket
@@ -67,10 +75,10 @@ To get the Organizations tags, we need to update the Lambda function to pull thi
                    for account in response["Accounts"]:
                       aid = account["Id"]                
                       if tags_check != '':
-                            tags_list = client.list_tags_for_resource(ResourceId=aid) #gets the lists of tags for this account
+                            tags_list = list_tags(aid) #gets the lists of tags for this account
                             
                             for tag in os.environ.get("TAGS").split(","): #looking at tags in the enviroment variables split by a space
-                               for org_tag in tags_list['Tags']:
+                               for org_tag in tags_list:
                                   if tag == org_tag['Key']: #if the tag found on the account is the same as the current one in the environent varibles, add it to the data
                                         value = org_tag['Value']
                                         kv = {tag : value}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When calling `list_tags_for_resource`, the lambda ignore any tags that do not fit in the first page of results. By paginating, the lambda gets all tags, even if they span more than one page. 

The indentation is super weird in the script (sometimes 5 spaces, sometimes 3). I tried to not deviate too much.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
