### PR TITLE
Removed references to Web1InstanceInstanceProfile

### DIFF
--- a/content/Reliability/200_Labs/200_Deploy_and_Update_CloudFormation/5_add_ec2.md
+++ b/content/Reliability/200_Labs/200_Deploy_and_Update_CloudFormation/5_add_ec2.md
@@ -45,7 +45,6 @@ For more details of this method, see: [AWS Compute Blog: Query for the latest Am
 
     You _only_ need to specify these six properties:
 
-    * **IamInstanceProfile:** References `Web1InstanceInstanceProfile`, which is defined elsewhere in the template
     * **ImageId:** References `LatestAmiId`, which is the parameter discussed previously
     * **InstanceType:** References `InstanceType`, another parameter
     * **SecurityGroupIds:** References `PublicSecurityGroup`, which is defined elsewhere in the template
@@ -74,7 +73,6 @@ For more details of this method, see: [AWS Compute Blog: Query for the latest Am
       MyEC2Instance:
         Type: AWS::EC2::Instance
         Properties:
-          IamInstanceProfile: !Ref Web1InstanceInstanceProfile
           ImageId: !Ref LatestAmiId
           InstanceType: !Ref InstanceType
           SecurityGroupIds:


### PR DESCRIPTION
[Initial instructions](https://wellarchitectedlabs.com/reliability/200_labs/200_deploy_and_update_cloudformation/5_add_ec2/
) include value for property `IamInstanceProfile` which causes an error due to value missing. Provided solution script does not include this property. The second example on the page does not include the property.

I didn't create an issue since removing the instruction would resolve it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
