### PR TITLE
Correct typo in SQL Query for EBS modernization

### DIFF
--- a/content/Cost/300_Labs/300_CUR_Queries/Queries/cost_optimization.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Queries/cost_optimization.md
@@ -267,7 +267,7 @@ If you are running this for all accounts in a large organization we recommend ru
 	select count (distinct line_item_resource_id) 
      FROM ${table_name}
      WHERE 
-		line_item_product_code = 'AmazonEC2') 
+		line_item_product_code = 'AmazonEC2' 
 		AND line_item_line_item_type = 'Usage' 
 		AND bill_payer_account_id <> ''
 		AND line_item_usage_account_id <> ''


### PR DESCRIPTION
Line 270 has a trailing parenthesis which leads to invalid sql syntax.

*Issue #, if available:*

*Description of changes:*

Remove trailing open parenthesis to correct the sql syntax of the query.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
