### PR TITLE
updated elasticsearch filter to match the new service name "Amazon OpenSearch Service"

### DIFF
--- a/content/Cost/300_Labs/300_CUR_Queries/Queries/analytics.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Queries/analytics.md
@@ -238,7 +238,7 @@ FROM
   ${table_name}
 WHERE
   ${date_filter}
-  AND product_product_name = 'Amazon Elasticsearch Service'
+  AND product_product_name in ('Amazon Elasticsearch Service' ,'Amazon OpenSearch Service')
   AND line_item_line_item_type  IN ('DiscountedUsage', 'Usage', 'SavingsPlanCoveredUsage')
 GROUP BY
   bill_payer_account_id,

--- a/content/Cost/300_Labs/300_CUR_Queries/Queries/analytics.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Queries/analytics.md
@@ -239,6 +239,7 @@ FROM
 WHERE
   ${date_filter}
   AND product_product_name in ('Amazon Elasticsearch Service' ,'Amazon OpenSearch Service')
+  AND line_item_product_code = 'AmazonES'
   AND line_item_line_item_type  IN ('DiscountedUsage', 'Usage', 'SavingsPlanCoveredUsage')
 GROUP BY
   bill_payer_account_id,


### PR DESCRIPTION
Simply update the when condition to match both the old and new AWS name for ElasticSearch service (now OpenSearch)
