### PR TITLE
Adding stress command requirements

### DIFF
--- a/content/Performance Efficiency/100_Labs/100_Monitoring_Linux_EC2_CloudWatch/5_generating_load.md
+++ b/content/Performance Efficiency/100_Labs/100_Monitoring_Linux_EC2_CloudWatch/5_generating_load.md
@@ -16,7 +16,15 @@ tags:
 We have a CloudWatch dashboard to show us CPU and Memory statistics for the deployed EC2 instance. In order to showcase the dashboards, lets add a synthetic load to the machine.
 
 ## Stress
-For this lab, the EC2 instance will install a utility called stress.  This tool is designed to subject your system to a configurable measure of CPU, memory, I/O and disk stress.  This command we will use:
+For this lab, the EC2 instance will install a utility called stress.  This tool is designed to subject your system to a configurable measure of CPU, memory, I/O and disk stress. 
+
+Stress tools is not installed by default, you will need to install the package in advance:
+```
+sudo amazon-linux-extras install epel -y
+sudo yum install stress -y
+```
+ 
+To use this command we will use:
 ```
 sudo stress --cpu 8 --vm-bytes $(awk '/MemAvailable/{printf "%d\n", $2 * 0.9;}' < /proc/meminfo)k --vm-keep -m 1
 ```
@@ -28,7 +36,6 @@ sudo stress --cpu 8 --vm-bytes $(awk '/MemAvailable/{printf "%d\n", $2 * 0.9;}' 
   * This will re-dirty memory instead of freeing and reallocating.
 * -m 1
   * This will spawn 1 worker spinning on malloc()/free()
-  
 
 ## Generate Load
 


### PR DESCRIPTION
Adding "stress" command requirements for Amazon Linux.  By default stress tools are not installed.

*Issue #, if available:*

When you try to execute the "GENERATE CPU AND MEMORY LOAD" workshop the command "stress" fails:
"**sudo: stress: command not found**"

Not everyone using this documentation is following the whole lab.  
When some search in google "how to stress ec2 instance"  this lab is the second outcome.   The documentation added, give visibility on the missing requirements, to avoid the error and execute stress successfully. 

*Description of changes:*
Lines of documentation added, plus commands required to execute stress without any issue, if required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
