### PR TITLE
bugfix in globals/region query

### DIFF
--- a/content/Cost/300_Labs/300_CUR_Queries/Queries/global.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Queries/global.md
@@ -151,7 +151,7 @@ Amortized Cost [Link](https://console.aws.amazon.com/cost-management/home?#/cust
         WHEN (line_item_line_item_type = 'RIFee') THEN (-reservation_amortized_upfront_fee_for_billing_period)
         WHEN (line_item_line_item_type = 'SavingsPlanNegation') THEN (-line_item_unblended_cost ) 
         ELSE 0 
-      END) AS ri_sp_trueup
+      END) AS ri_sp_trueup,
       SUM(CASE
         WHEN (line_item_line_item_type = 'SavingsPlanUpfrontFee') THEN line_item_unblended_cost
         WHEN ((line_item_line_item_type = 'Fee') AND (reservation_reservation_a_r_n <> '')) THEN line_item_unblended_cost 


### PR DESCRIPTION
missing comma in select statement

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
