### PR TITLE
fix: update default value for VPC name to match export name in WebApp…

### DIFF
--- a/static/Reliability/Common/Code/CloudFormation/staticwebapp.yaml
+++ b/static/Reliability/Common/Code/CloudFormation/staticwebapp.yaml
@@ -30,7 +30,7 @@ Parameters:
   VPCImportName:
     Type: String
     Description: 'The CloudFormation name of the VPC stack to import'
-    Default: 'WebApp1-VPC'
+    Default: 'WebApp1-Vpc'
     MinLength: '3'
     MaxLength: '32'
   VPCImportApp1Instance1Subnet1:


### PR DESCRIPTION
update default value for VPC name to match export name in WebApp1-Vpc stack

*Issue #, if available:*

*Description of changes:*
This stack tries to import `VPCImportName` variable from WebApp1-Vpc stack outputs, and with current config, it fails with error:
```
No export named WebApp1-VPC-App1Subnet2 found. Rollback requested by user.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
