### PR TITLE
Add type field

### DIFF
--- a/content/Operational Excellence/100_Labs/100_Inventory_Patch_Management/7_create_sns_topic.md
+++ b/content/Operational Excellence/100_Labs/100_Inventory_Patch_Management/7_create_sns_topic.md
@@ -15,6 +15,7 @@ To create and subscribe to an SNS topic:
 1. Navigate to the SNS console at <https://console.aws.amazon.com/sns/>.
 1. Choose **Create topic**.
 1. In the **Create new topic** window:
+   1. In the **Type** field, select `Standard`.
    1. In the **Topic name** field, enter `AdminAlert`.
    1. In the **Display name** field, enter `AdminAlert`.
    1. Choose **Create topic**.


### PR DESCRIPTION
SNS topic defaults to FIFO, which does not support email. Update instructions to specify Standard type.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
