### PR TITLE
Fix hugo errors with version 0.92

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -10,7 +10,6 @@
         {{ partial "search.html" . }}
     {{end}}
   </div>
-
     <div class="highlightable">
     <ul class="topics">
 
@@ -94,14 +93,17 @@
 {{ define "section-tree-nav" }}
 {{ $showvisitedlinks := .showvisitedlinks }}
 {{ $currentNode := .currentnode }}
+{{ $currentFileUniqueID := "" }}
+{{ with $currentNode.File }}{{ $currentFileUniqueID = .UniqueID }}{{ end }}
  {{with .sect}}
-  {{if .IsSection}}
+  {{if and .IsSection (or (not .Params.hidden) $.showhidden)}}
     {{safeHTML .Params.head}}
     {{ $isParent := or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
     {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
-    <li data-nav-id="{{.URL}}" title="{{.Title}}" class="dd-item
-    {{if $isParent }}parent{{end}}
-        {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}
+    <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item
+        {{if .IsAncestor $currentNode }}parent{{end}}
+        {{if eq .File.UniqueID $currentFileUniqueID}}active{{end}}
+        {{if .Params.alwaysopen}}parent{{end}}
         ">
       <a href="{{.RelPermalink}}">
           {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
@@ -116,6 +118,7 @@
             <i class="fas read-icon"></i>
           {{ end }}
       </a>
+      {{ $numberOfPages := (add (len ( where .Pages "Params.hidden" "ne" true )) (len ( where .Sections "Params.hidden" "ne" true ))) }}
       {{ if ne $numberOfPages 0 }}
         <ul>
           {{ $currentNode.Scratch.Set "pages" .Pages }}
@@ -144,7 +147,7 @@
     </li>
   {{else}}
     {{ if not .Params.Hidden }}
-      <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}">
+      <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item {{if eq .File.UniqueID $currentFileUniqueID}}active{{end}}">
         <a href="{{ .RelPermalink}}">
         {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
         {{ if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -97,7 +97,7 @@ Parameters:
 {{ else }}
 
 {{/* Make relative: Fetch the current directory and then append it to the specified `file=""` value */}}
-{{ $.Scratch.Set "filepath" $.Page.Dir }}
+{{ $.Scratch.Set "filepath" $.File.Dir }}
 {{ $.Scratch.Add "filepath" ( .Get "file" ) }}
 
 {{ end }}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -46,7 +46,7 @@
 				{{ end }}
 			{{ end }}
 		{{ else}}
-		{{ $path := path.Join $.Page.Dir .include }}
+		{{ $path := path.Join $.File.Dir .include }}
 		{{ $page := $.Page.Site.GetPage "page" $path }}
 		{{ with $page }}
 			{{ .Content }}

--- a/themes/learn/layouts/partials/menu.html
+++ b/themes/learn/layouts/partials/menu.html
@@ -32,7 +32,7 @@
         <ul>
           {{ range sort . "Weight"}}
               <li> 
-                  {{.Pre}}<a class="padding" href="{{.URL | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
+                  {{.Pre}}<a class="padding" href="{{.Params.url | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
               </li>
           {{end}}
         </ul>

--- a/themes/learn/layouts/shortcodes/attachments.html
+++ b/themes/learn/layouts/shortcodes/attachments.html
@@ -4,14 +4,14 @@
 		<i class="fas fa-paperclip" aria-hidden="true"></i>
 		{{with .Get "title"}}{{.}}{{else}}{{T "Attachments-label"}}{{end}}
 	</label>
-	{{if eq .Page.File.BaseFileName "index"}}
+	{{if eq .File.Dir.BaseFileName "index"}}
 		{{$.Scratch.Add "filesName" "files"}}
 	{{else}}
-		{{$.Scratch.Add "filesName" (printf "%s.files" .Page.File.BaseFileName)}}
+		{{$.Scratch.Add "filesName" (printf "%s.files" .File.BaseFileName)}}
 	{{end}}
 	<div class="attachments-files">
-	{{ range (readDir (printf "./content/%s%s" .Page.File.Dir ($.Scratch.Get "filesName")) ) }}
-		{{ $fileDir := replace $.Page.File.Dir "\\" "/" }}
+	{{ range (readDir (printf "./content/%s%s" .File.Dir ($.Scratch.Get "filesName")) ) }}
+		{{ $fileDir := replace $.File.Dir "\\" "/" }}
 		{{if ($.Get "pattern")}}
 			{{if (findRE ($.Get "pattern") .Name)}}
 				<li>

--- a/themes/learn/layouts/shortcodes/children.html
+++ b/themes/learn/layouts/shortcodes/children.html
@@ -10,7 +10,7 @@
 
 	{{if .Page.IsHome}}
 		<!-- Add pages that are in root dir -->
-		{{ $rootPage := where .Page.Pages "Dir" "" }}
+		{{ $rootPage := where .Page.Pages "File.Dir" "" }}
 		{{ .Scratch.Set "pages" (.Page.Sections | union $rootPage)}}
 	{{else}}
 		{{ if .Page.Sections}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes errors and warnings when running `hugo serve -D`

```
➜  aws-well-architected-labs-fork git:(master) ✗ hugo serve -D                                      
Start building sites … 
hugo v0.92.0+extended darwin/amd64 BuildDate=unknown
ERROR 2022/01/21 16:08:01 Page.URL is deprecated and will be removed in Hugo 0.93.0. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url
ERROR 2022/01/21 16:08:09 Page.Dir is deprecated and will be removed in Hugo 0.93.0. Use .File.Dir
WARN 2022/01/21 16:08:12 .File.UniqueID on zero object. Wrap it in if or with: {{ with .File }}{{ .UniqueID }}{{ end }}
```

**Some of these are inherited from https://github.com/matcornic/hugo-theme-learn so maybe we could fix them in a more robust way by upgrading the whole theme?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
