### PR TITLE
Update _index.md

### DIFF
--- a/content/Cost/300_Labs/300_CUR_Queries/Query_Help/_index.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Query_Help/_index.md
@@ -457,9 +457,9 @@ Accounts have both RI and SP usage during the billing period
       WHEN ((line_item_line_item_type = 'Fee') AND (reservation_reservation_a_r_n <> '')) THEN line_item_unblended_cost 
       ELSE 0 
     END) AS ri_sp_upfront_fees
-
+```
 Accounts have SP usage but no RI usage during the billing period
-
+```tsql
     DATE_FORMAT((line_item_usage_start_date),'%Y-%m-01') AS month_line_item_usage_start_date,
     SUM(CASE
       WHEN (line_item_line_item_type = 'SavingsPlanNegation') THEN 0 


### PR DESCRIPTION
In the Reserved Instance and Savings Plan Example, there was a line of text embedded in the tsql code section.  There should actually be 2 sections of code, one for when there is SP and RI usage both, an one when there is SP usage only.  I have edited this page to separate the 2 code bodies and move the line of text between them outside of the code blocks.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
