### PR TITLE
add prereqs for kpi_dashboard

### DIFF
--- a/content/Cost/200_Labs/200_Cloud_Intelligence/Cost & Usage Report Dashboards/Dashboards/2c_kpi_dashboard.md
+++ b/content/Cost/200_Labs/200_Cloud_Intelligence/Cost & Usage Report Dashboards/Dashboards/2c_kpi_dashboard.md
@@ -24,6 +24,13 @@ The KPI and Modernization Dashboard helps your organization combine DevOps and I
 - [Explore a sample KPI Dashboard](https://d1s0yx3p3y3rah.cloudfront.net/anonymous-embed?dashboard=kpi) 
 
 ![kpi_sample](/Cost/200_Cloud_Intelligence/Images/kpi/kpi_sample.png?classes=lab_picture_small)
+
+## Prerequisites
+KPI dashboard can be only be installed if following products are in billing history (CUR)
+- RDS
+- Elasticache
+If you do not have these products you can install and then delete instances of each product after 1 hour.
+
 	
 ## Deployment Options
 There are 3 options to deploy the KPI Dashboard. The CloudFormation template is coming soon. Bookmark the [KPI Dashboard Changelog](https://github.com/aws-samples/aws-cudos-framework-deployment/blob/main/changes/CHANGELOG-kpi.md) for the latest version and updates. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add doc for kpi_dashboard. This address a reccurent issue with kpi_dashboard install, warns user that RDS and Elasticache instances are required for successful install. Also a workaround provided. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
