### PR TITLE
fail_az.py updates multiple ASGs

### DIFF
--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/python/fail_az.py
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/python/fail_az.py
@@ -1,12 +1,12 @@
 #
 # MIT No Attribution
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this
 # software and associated documentation files (the "Software"), to deal in the Software
 # without restriction, including without limitation the rights to use, copy, modify,
 # merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 # PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
@@ -26,22 +26,22 @@ NetworkAclAssociationIds = []
 ec2client = boto3.client('ec2')
 rds = boto3.client('rds')
 client = boto3.client('autoscaling')
-vpc_id = sys.argv[1] 
+vpc_id = sys.argv[1]
 az_id = sys.argv[2]
 response = client.describe_auto_scaling_groups()
 ASG = response['AutoScalingGroups']
-new_subnets = []
 
 # Go though the auto scaling groups (there is only one) and identify the AZs and Subnets
 for asg in ASG:
     as_group = asg['AutoScalingGroupName']
     Subnets = asg['VPCZoneIdentifier'].split(',')
 
-# Loop through the AZs and Subnets
+    # Loop through the AZs and Subnets
+    new_subnets = []
     i = 0
     while i < len(Subnets):
         subnet = Subnets[i]
-# Describe the subnet so you can see if it is in the AZ
+        # Describe the subnet so you can see if it is in the AZ
         subnet_resp = ec2client.describe_subnets(Filters=[
                                   {
                                       'Name'   : 'subnet-id',
@@ -54,25 +54,24 @@ for asg in ASG:
                                   ])
 
         subnet_desc = subnet_resp['Subnets'][0]
-# If it's not the AZ to fail, then we will use the subnet in the new config
+        # If it's not the AZ to fail, then we will use the subnet in the new config
         if subnet_desc['AvailabilityZone'] != az_id:
 
             new_subnets.append(subnet)
         i = i + 1
-    break
 
-#Create the string to pass to the API
-new_az_string =""
-i = 0
-while i < len(new_subnets):
-    new_az_string = new_az_string + new_subnets[i]
-    if (i != len(new_subnets) - 1):
-        new_az_string = new_az_string + ", "
-    i = i + 1
+    #Create the string to pass to the API
+    new_az_string =""
+    i = 0
+    while i < len(new_subnets):
+        new_az_string = new_az_string + new_subnets[i]
+        if (i != len(new_subnets) - 1):
+            new_az_string = new_az_string + ", "
+        i = i + 1
 
-#Update the autoscaling group with the new list of subnets
-print("Updating " + as_group + " to be in the following AZs: " + new_az_string)
-response = client.update_auto_scaling_group(AutoScalingGroupName=as_group, VPCZoneIdentifier=new_az_string)
+    #Update the autoscaling group with the new list of subnets
+    print("Updating " + as_group + " to be in the following AZs: " + new_az_string)
+    response = client.update_auto_scaling_group(AutoScalingGroupName=as_group, VPCZoneIdentifier=new_az_string)
 
 #Get a list of the subnets on the VPC
 response = ec2client.describe_subnets(Filters=[
@@ -92,7 +91,7 @@ while i < len(subnets):
     subnets_to_change.append(subnets[i]['SubnetId'])
     i = i + 1
 
-#Find  network acl associations mapped to the subnets identified above            
+#Find  network acl associations mapped to the subnets identified above
 nacl_response = ec2client.describe_network_acls(Filters=[
                                                         {
                                                                 'Name': 'association.subnet-id',
@@ -117,12 +116,12 @@ new_nacl_id = associations['NetworkAclId']
 Egress = ec2client.create_network_acl_entry(
     CidrBlock='0.0.0.0/0',Egress=True,PortRange={  'From': 0,'To': 65535,},NetworkAclId=new_nacl_id,
     Protocol= '-1',RuleAction='deny',  RuleNumber=100,
-   
-)   
+
+)
 Ingress = ec2client.create_network_acl_entry(
     CidrBlock='0.0.0.0/0',Egress=False,PortRange={  'From': 0,'To': 65535,},NetworkAclId =new_nacl_id,
     Protocol= '-1' ,RuleAction='deny',  RuleNumber=101,
-   
+
 )
 # Replace the association IDs with a new one for this NetworkACL
 
@@ -131,7 +130,7 @@ print("Associating new network ACL to the subnets in the AZ")
 print("Updating NACLs on:")
 for sn in  subnets_to_change:
     print (sn)
-for nacl_association_id in NetworkAclAssociationIds:    
+for nacl_association_id in NetworkAclAssociationIds:
     replace_network_acl_association = ec2client.replace_network_acl_association(
          AssociationId=nacl_association_id,
          NetworkAclId=new_nacl_id
@@ -141,7 +140,7 @@ for nacl_association_id in NetworkAclAssociationIds:
 dbs = rds.describe_db_instances()
 
 for db in dbs['DBInstances']:
-  if db['DBSubnetGroup']['VpcId'] == vpc_id:    
+  if db['DBSubnetGroup']['VpcId'] == vpc_id:
     try:
         if (db['AvailabilityZone'] == az_id) and (len(db['SecondaryAvailabilityZone']) > 0):
             print ("Rebooting the RDS instance " + db['DBInstanceIdentifier'])


### PR DESCRIPTION
I've created a patch for #509 .

Currently `fail_az.py` script updates only one ASG (described in the below comment).
https://github.com/awslabs/aws-well-architected-labs/issues/509#issuecomment-1121333748

After applying this patch, `fail_az.py` can update multiple ASGs which belong to "failed" AZ like the following.

<img width="1033" alt="fail_az_after_patch" src="https://user-images.githubusercontent.com/7800796/168426978-104e4b80-8083-4168-847b-29d4039a0c68.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
