### PR TITLE
Make it clearer to use the sample parquet files

### DIFF
--- a/content/Cost/200_Labs/200_4_Cost_and_Usage_Analysis/1_Verify_CUR.md
+++ b/content/Cost/200_Labs/200_4_Cost_and_Usage_Analysis/1_Verify_CUR.md
@@ -5,6 +5,12 @@ chapter: false
 weight: 1
 pre: "<b>1. </b>"
 ---
+
+{{% notice note %}}
+Prerequisite:
+You must have configured Cost and Usage Reports in the [AWS Account Setup]({{< ref "/Cost/100_Labs/100_1_AWS_Account_Setup" >}}) lab. It can take up to 24 hours for AWS to deliver the first report to your Amazon S3 bucket. However if you are doing this Lab as part of an AWS workshop, or do not have substantial or interesting usage, follow [these steps]({{< ref "#use-sample-data" >}}) at the bottom of this lab to create an Amazon S3 bucket and use sample files.
+{{% /notice %}}
+
 We will verify the CUR files are being delivered, they are in the correct format and the region they are in.
 
 1. Log into the console via SSO.
@@ -31,13 +37,22 @@ We will verify the CUR files are being delivered, they are in the correct format
 You have successfully verified that you have access to the CUR files, and they are being delivered in the correct format.
 {{% /notice %}}
 
+### Use Sample Data
 
+{{%expand "Click here to use sample CUR data" %}}
 
-**Sample Files**
-You may not have substantial or interesting usage, in this case there are sample files below. Create a folder structure, such as (bucket name)/cur/WorkshopCUR/WorkshopCUR/year=2018/month=x and copy the parquet files below into each months folder:
+1. Follow the Amazon Simple Storage Service [documentation page](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket
+2. Select your new S3 bucket and click the **Create folder** button, enter `cur` for your folder name, and click **Create folder**
+3. Click on your new `cur` folder to enter it, and follow the same process to create further folders until you have a folder structure which resembles **(bucket name)/cur/WorkshopCUR/WorkshopCUR/year=2018**
+4. Then create three further folders within the **year=2018** folder (**month=10**, **month=11**, **month=12**)
+5. Download the three parquet files below
 
 - [October 2018 Usage](/Cost/200_4_Cost_and_Usage_Analysis/Code/Oct2018-WorkshopCUR-00001.snappy.parquet)
 - [November 2018 Usage](/Cost/200_4_Cost_and_Usage_Analysis/Code/Nov2018-WorkshopCUR-00001.snappy.parquet)
 - [December 2018 Usage](/Cost/200_4_Cost_and_Usage_Analysis/Code/Dec2018-WorkshopCUR-00001.snappy.parquet)
+
+6. Upload each months file into the corresponding folder, (so upload  October's parquet file to **(bucket name)/cur/WorkshopCUR/WorkshopCUR/year=2018/month=10/**
+
+{{% /expand%}}
 
 {{< prev_next_button link_prev_url="../" link_next_url="../2_setup_athena/" />}}

--- a/content/Cost/200_Labs/200_4_Cost_and_Usage_Analysis/_index.md
+++ b/content/Cost/200_Labs/200_4_Cost_and_Usage_Analysis/_index.md
@@ -15,6 +15,7 @@ July 2021
 
 ## Contributors
 - Alee Whitman, Sr. Commercial Architect (AWS OPTICS) 
+- Duncan Bell, Solutions Architect, Well-Architected
 
 ## Feedback
 If you wish to provide feedback on this lab, there is an error, or you want to make a suggestion, please email: costoptimization@amazon.com


### PR DESCRIPTION
Make it clearer to use the sample parquet files if doing this workshop without CUR setup first

*Issue #, if available:*

*Description of changes:*
Update COST Lab to make instructions on using sample CUR reports easier to follow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
