### PR TITLE
Fixed issue lambda_handler Exception:- 'NoneType' object is not itera…

### DIFF
--- a/static/Security/300_VPC_Flow_Logs_Analysis_Dashboard/code/vpc_athena_db_table_view_lambda_parquet.yaml
+++ b/static/Security/300_VPC_Flow_Logs_Analysis_Dashboard/code/vpc_athena_db_table_view_lambda_parquet.yaml
@@ -306,7 +306,7 @@ Resources:
               frequency = event["ResourceProperties"]["frequency"] if event.get("ResourceProperties") != None else event["frequency"]
               s3_buckcet_flow_log = event["ResourceProperties"]["VpcFlowLogsBucketName"] if event.get("ResourceProperties") != None else event["VpcFlowLogsBucketName"]
               s3_ouput = event["ResourceProperties"]["s3Output"] if event.get("ResourceProperties") != None else event["s3Output"]
-              s3_account_prefix=event["ResourceProperties"]["VpcFlowLogsFilePrefix"] + "/AWSLogs/" if event.get("ResourceProperties") != None else event["VpcFlowLogsFilePrefix"] + "/AWSLogs/"
+              s3_account_prefix=event["ResourceProperties"]["VpcFlowLogsFilePrefix"] + "AWSLogs/" if event.get("ResourceProperties") != None else event["VpcFlowLogsFilePrefix"] + "/AWSLogs/"
               hive_compatible_s3_prefix = event["ResourceProperties"]["HiveCompatibleS3prefix"] if event.get("ResourceProperties") != None else event["HiveCompatibleS3prefix"]
               account_result = s3.list_objects(Bucket=s3_buckcet_flow_log,Prefix=s3_account_prefix, Delimiter='/')
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When creating Athena resources one of the lambda function causes an error due to extra "/" in s3 path
Error: ```lambda is : lambda_handler Exception:- 'NoneType' object is not iterable```

This PR fixes above mentioned issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
