### PR TITLE
Don't include **.csv.metadata

### DIFF
--- a/content/Cost/200_Labs/200_Cloud_Intelligence/FAQ/_index.md
+++ b/content/Cost/200_Labs/200_Cloud_Intelligence/FAQ/_index.md
@@ -118,7 +118,7 @@ These actions should be done in Governance account
 
 ![Images/glue_1.png](/Cost/200_Cloud_Intelligence/Images/glue_1.png?classes=lab_picture_small)
 
-5. In Add a data store select S3 bucket name with aggregated CUR data and add following exclusions **.zip, **.json, **.gz, **.yml, **.sql, **.csv.*, **/cost_and_usage_data_status/*, aws-programmatic-access-test-object. Click Next
+5. In Add a data store select S3 bucket name with aggregated CUR data and add following exclusions **.zip, **.json, **.gz, **.yml, **.sql, **.csv, **.csv.metadata, **/cost_and_usage_data_status/*, aws-programmatic-access-test-object. Click Next
 
 ![Images/glue_2.png](/Cost/200_Cloud_Intelligence/Images/glue_2.png?classes=lab_picture_small)
 

--- a/content/Cost/200_Labs/200_Cloud_Intelligence/FAQ/_index.md
+++ b/content/Cost/200_Labs/200_Cloud_Intelligence/FAQ/_index.md
@@ -118,7 +118,7 @@ These actions should be done in Governance account
 
 ![Images/glue_1.png](/Cost/200_Cloud_Intelligence/Images/glue_1.png?classes=lab_picture_small)
 
-5. In Add a data store select S3 bucket name with aggregated CUR data and add following exclusions **.zip, **.json, **.gz, **.yml, **.sql, **.csv, **/cost_and_usage_data_status/*, aws-programmatic-access-test-object. Click Next
+5. In Add a data store select S3 bucket name with aggregated CUR data and add following exclusions **.zip, **.json, **.gz, **.yml, **.sql, **.csv.*, **/cost_and_usage_data_status/*, aws-programmatic-access-test-object. Click Next
 
 ![Images/glue_2.png](/Cost/200_Cloud_Intelligence/Images/glue_2.png?classes=lab_picture_small)
 


### PR DESCRIPTION
*Issue #, if available:* #653

*Description of changes:*
Currently the crawler creates many tables from the csv metadata that have no collumns. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
