### PR TITLE
Fixed hint for Outputs

### DIFF
--- a/content/Reliability/100_Labs/100_Deploy_CloudFormation/3_explore_webapp.md
+++ b/content/Reliability/100_Labs/100_Deploy_CloudFormation/3_explore_webapp.md
@@ -12,7 +12,7 @@ pre: "<b>3. </b>"
     * Click on the **CloudFormationLab** stack
     * Click on the **Outputs** tab
     * For the Key **WebsiteURL** copy the value.  This is the URL of your test web service
-      * _Hint_: it will start with _`http://healt-alb`_ and end in _`<aws region>.elb.amazonaws.com`_
+      * _Hint_: it will end in _`<aws region>.elb.amazonaws.com`_
     
 
 1. Click the URL and it will bring up the website: 


### PR DESCRIPTION
The hint stating how the WebsiteURL starts is not correct any longer. However, the ending is still valid

*Issue #, if available:*

*Description of changes:*
Removed the start with part of the hint for the outputs on the CloudFormationLab

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
