### PR TITLE
Fix Prev/Next links in Disaster Recovery Lab prerequisite section

### DIFF
--- a/content/Reliability/Disaster Recovery/Workshop_1/1-prerequisites/1.1-account-setup/1.1.2-primary-region/_index.en.md
+++ b/content/Reliability/Disaster Recovery/Workshop_1/1-prerequisites/1.1-account-setup/1.1.2-primary-region/_index.en.md
@@ -28,4 +28,4 @@ weight = 2
 
 {{< img pr-5.png >}}
 
-{{< prev_next_button link_prev_url="../1.1.1-s3-access" link_next_url="../1.1.3-secondary-region" />}}
+{{< prev_next_button link_prev_url="../1.1.1-s3-access/" link_next_url="../1.1.3-secondary-region/" />}}


### PR DESCRIPTION
Previous and Next URLs require trailing / to work correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
