### PR TITLE
Fix `FROM_ISO8601_TIMESTAMP` example

### DIFF
--- a/content/Cost/300_Labs/300_CUR_Queries/Query_Help/_index.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Query_Help/_index.md
@@ -159,7 +159,7 @@ WHERE line_item_usage_start_date >= CAST('2020-07-01 00:00:00' AS TIMESTAMP)
 
 **Example: Arbitrary Date/Time until Present (July 8, 2020 01:23:45AM - Present)**
 ```tsql
-WHERE line_item_usage_start_date >= FROM_ISO8601_TIMESTAMP('2020-07-01 01:23:45')
+WHERE line_item_usage_start_date >= FROM_ISO8601_TIMESTAMP('2020-07-01T01:23:45')
 ```
 
 **Example: Previous 3 Months Before Now**  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`FROM_ISO8601_TIMESTAMP` does not accept `2020-07-01 01:23:45` (other examples in the file are valid).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
