### PR TITLE
REL300-Chaos fix issue: not authorized to perform CreateLogGroup with…

### DIFF
--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy.json
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy.json
@@ -385,8 +385,6 @@
                 "iam:AttachRolePolicy",
                 "iam:CreateInstanceProfile",
                 "iam:CreateRole",
-                "iam:DescribeInstanceProfiles",
-                "iam:DescribeRoles",
                 "iam:PassRole",
                 "iam:PutRolePolicy",
                 "iam:GetRolePolicy",
@@ -405,6 +403,7 @@
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
                 "logs:DescribeLogGroups",
+                "logs:TagLogGroup",
                 "ssm:GetParameter",
                 "s3:CreateBucket",
                 "synthetics:CreateCanary"

--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy_two_regions.json
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy_two_regions.json
@@ -424,8 +424,6 @@
                 "iam:AttachRolePolicy",
                 "iam:CreateInstanceProfile",
                 "iam:CreateRole",
-                "iam:DescribeInstanceProfiles",
-                "iam:DescribeRoles",
                 "iam:PassRole",
                 "iam:PutRolePolicy",
                 "iam:GetRolePolicy",


### PR DESCRIPTION
Fix this issue

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



CREATE_FAILED | Resource handler   returned message: "User with accountId: 254377943029 is not authorized   to perform CreateLogGroup with Tags (Service: CloudWatchLogs, Status Code:   400, Request ID: 72c1fa9c-01d6-41c3-9366-a54cb0626a9a)" (RequestToken:   62e9f7dd-54a0-72e2-6a70-5aac51d772be, HandlerErrorCode:   GeneralServiceException) | AWS::Logs::LogGroup
-- | -- | --




</div>

<!--EndFragment-->
</body>

</html>


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
