### PR TITLE
Updated fail_rds.py to exit loop only on successful failover

### DIFF
--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/python/fail_rds.py
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/FailureSimulations/python/fail_rds.py
@@ -39,7 +39,7 @@ try:
                     DBInstanceIdentifier=db['DBInstanceIdentifier'],
                     ForceFailover=True|False
           )
-    break
+          break
 
 except Exception as error:
     print(error)


### PR DESCRIPTION
*Issue #, if available:*
757
https://github.com/awslabs/aws-well-architected-labs/issues/757

*Description of changes:*
Moved exit loop `break` into the `if` statement block causing the loop to exit only after successful execution of the failover procedure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
