### PR TITLE
Updated typo in Athena Query for account_map

### DIFF
--- a/content/Cost/300_Labs/300_Optimization_Data_Collection/4_Utilize_Data.md
+++ b/content/Cost/300_Labs/300_Optimization_Data_Collection/4_Utilize_Data.md
@@ -34,7 +34,7 @@ You can also use the below query to update your **account_map** table in athena 
       , name account_name
       , email account_email_id
       FROM
-        "optimization_data"."organisation_data" 
+        "optimization_data"."organization_data" 
 
 {{% /expand%}}
 


### PR DESCRIPTION
changed from "organisation_data" to "organization_data" to match existing schema

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
