### PR TITLE
Update typo in Athena query for account_map

### DIFF
--- a/content/Cost/200_Labs/200_Cloud_Intelligence/Cost & Usage Report Dashboards/Dashboards/Code/0_view0.md
+++ b/content/Cost/200_Labs/200_Cloud_Intelligence/Cost & Usage Report Dashboards/Dashboards/Code/0_view0.md
@@ -187,7 +187,7 @@ Create or update your account_map view by running the following query.
 			"id" "account_id", 
 			"name" "account_name"
 		FROM
-			"optimization_data"."organisation_data"
+			"optimization_data"."organization_data"
 
 #### Option3-B: Complete sections 1-3 of the Level 300: Organization Data CUR Connection Lab 
 


### PR DESCRIPTION
(related to #791 )
Found the same typo in this page. Updated "organisation_data" to "organization_data"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
