### PR TITLE
Excluding used ODCR hours from EC2 hours per day CUR query

### DIFF
--- a/content/Cost/300_Labs/300_CUR_Queries/Queries/compute.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Queries/compute.md
@@ -120,6 +120,8 @@ WHERE
     OR (line_item_line_item_type = 'SavingsPlanCoveredUsage')
     OR (line_item_line_item_type = 'DiscountedUsage')
   )
+  -- excludes consumed ODCR running hours from total
+  AND product_capacitystatus != 'AllocatedCapacityReservation'
 GROUP BY 
   bill_billing_period_start_date,
   line_item_usage_start_date, 

--- a/content/Cost/300_Labs/300_CUR_Queries/Queries/compute.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Queries/compute.md
@@ -120,7 +120,7 @@ WHERE
     OR (line_item_line_item_type = 'SavingsPlanCoveredUsage')
     OR (line_item_line_item_type = 'DiscountedUsage')
   )
-  -- excludes consumed ODCR running hours from total
+  -- excludes consumed ODCR hours from total
   AND product_capacitystatus != 'AllocatedCapacityReservation'
 GROUP BY 
   bill_billing_period_start_date,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 
- Modifying the [EC2 hours per day query](https://wellarchitectedlabs.com/cost/300_labs/300_cur_queries/queries/compute/#ec2-hours-a-day) to exclude allocated ODCR hours.

*Context*: I typically use this query to emulate the `EC2: Running Hours` usage type group in Cost Explorer. The current query includes allocated hours for ODCRs, which can skew unit costs if not filtered out. In the CUR, these line items appear with a $0 unblended cost, so they don't affect the spend. However, the usage still appears. Adding a simple check to ignore the allocated ODCRs using the [`product/capacitystatus`](https://docs.aws.amazon.com/cur/latest/userguide/product-columns.html) matches how Cost Explorer handles it with the configuration above.

@awssteph, I'm happy to share an example with you offline, but I feel that this could benefit all customers and is a sensible default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
