### PR TITLE
update syn-nodejs-puppeteer version.

### DIFF
--- a/static/Operations/200_Automating_operations_with_playbooks_and_runbooks/Code/templates/base_app.yml
+++ b/static/Operations/200_Automating_operations_with_playbooks_and_runbooks/Code/templates/base_app.yml
@@ -498,7 +498,7 @@ Resources:
             - ''
             - - s3://
               - Ref: ResultsBucket
-        RuntimeVersion: syn-nodejs-puppeteer-3.0
+        RuntimeVersion: syn-nodejs-puppeteer-3.5
         Schedule: 
           Expression: 'rate(1 minute)'
           DurationInSeconds: 0


### PR DESCRIPTION
update syn-nodejs-puppeteer version. version 3.0 is deprecated and will cause deployment failure.

*Description of changes:* sync-nodejs-puppeteer version 3.0 is obsolete. It will fail to deploy in cloud formation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
