### PR TITLE
ecs cannot be used with old boto3 version

### DIFF
--- a/static/Cost/300_Optimization_Data_Collection/Code/module-compute-optimizer.yaml
+++ b/static/Cost/300_Optimization_Data_Collection/Code/module-compute-optimizer.yaml
@@ -327,7 +327,7 @@ Resources:
                               'auto_scale':   co.export_auto_scaling_group_recommendations,
                               'lambda':       co.export_lambda_function_recommendations,
                               'ebs_volume':   co.export_ebs_volume_recommendations,
-                              'ecs_service':  co.export_ecs_service_recommendations,
+                              # 'ecs_service':  co.export_ecs_service_recommendations,  # does not work with boto3 versions below 1.26
                           }
                           bkt = BUCKET_PREFIX + '-' + region
                           print(f"INFO: bucket={bkt}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
