### PR TITLE
Add exception handler to handle SCP deny for other regions

### DIFF
--- a/static/Cost/300_Optimization_Data_Collection/Code/module-rds-usage.yaml
+++ b/static/Cost/300_Optimization_Data_Collection/Code/module-rds-usage.yaml
@@ -337,7 +337,11 @@ Resources:
                                   client = assume_role(account_id, functions[service]['api'], region['RegionName'])
                                   for f in functions[service]['functions']:
                                       cw_client = assume_role(account_id, 'cloudwatch', region['RegionName'])
-                                      data = globals()[f['name']](cw_client, client, s3client, region['RegionName'], service, f['output_path'], f['output_file_name'], account_id, payer_id)
+                                      try:
+                                        data = globals()[f['name']](cw_client, client, s3client, region['RegionName'], service, f['output_path'], f['output_file_name'], account_id, payer_id)
+                                      except Exception as e:
+                                        # Send some context about this error to Lambda Logs
+                                        logging.warning(e)
                           else:
                               client=boto3.client(service)
                               for f in functions[service]['functions']:


### PR DESCRIPTION
*Issue #, if available:* 

https://github.com/awslabs/aws-well-architected-labs/issues/854


*Description of changes:*

In case of organization region deny, whole RDS usage data capture is failing. So added exception handler to get bypass the errors and capture the ones which are allowed. 

Ex : if there is a SCP which allows only regions ["ap-southeast-1", "us-east-1"] and denies the rest, the whole rds usage data capture is failing, if there are any region other than the allowed ones. 

Fails with the following error. 

```
	An error occurred (AccessDenied) when calling the DescribeDBInstances operation: User: arn:aws:sts::xxx:assumed-role/xxxAssumeRoleRoot is not authorized to perform: rds:DescribeDBInstances on resource: arn:aws:rds:ap-south-1:xxx:db:* with an explicit deny in a service control policy

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
