### PR TITLE
Fix to strip whitespace from links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,1 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>{{- "" -}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently any links that are followed with a punctuation mark will have a extra space.  For example on the front page: "are not covered in the [AWS Free Tier](https://aws.amazon.com/free/) ." Adding in {{- "" -}} at the very end of the URL shortcode strips the extra space.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
