### PR TITLE
300Chaos fix several bugs

### DIFF
--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/web_server_autoscaling.json
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/web_server_autoscaling.json
@@ -33,8 +33,8 @@
     "WebServerInstanceType" : {
       "Description" : "EC2 instance type",
       "Type" : "String",
-      "Default" : "t2.micro",
-      "AllowedValues" : [ "t2.micro", "t2.small", "t2.medium", "t2.large", "t2.xlarge" ]
+      "Default" : "t4g.micro",
+      "AllowedValues" : [ "t4g.micro", "t4g.small", "t4g.medium", "t4g.large", "t4g.xlarge" ]
     },
 
     "AvailabilityZones" : {
@@ -141,6 +141,7 @@
               "source /home/ec2-user/venv/bin/activate\n",
               "pip install ec2_metadata\n",
               "pip install pymysql\n",
+              "pip install urllib3==1.26.6\n",
               "wget https://s3.", { "Ref" : "BootBucketRegion" }, ".amazonaws.com/" , { "Ref" : "BootBucket" }, "/", { "Ref" : "BootPrefix" }, { "Ref" : "BootObject" }, "\n",
               "python3 ", { "Ref" : "BootObject" }, " -u ", { "Ref" : "WebSiteImage" }, " -p 80 -s ", { "Ref" : "RDSUser" }, " -w ", { "Ref" : "RDSPassword"}, " -d iptracker -o ", { "Ref" : "RDSHostName"}, "\n"
             ]]
@@ -350,7 +351,7 @@
             "ArtifactS3Location": {
                 "Fn::Sub": "s3://${CanaryBucket}"
             },
-            "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+            "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
             "Schedule": {
                 "Expression": "rate(1 minute)"
             },

--- a/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/WebAppLambda/deploy_web_lambda.py
+++ b/static/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/WebAppLambda/deploy_web_lambda.py
@@ -33,9 +33,7 @@ AWS_REGION = 'us-east-2'
 
 ARCH_TO_AMI_NAME_PATTERN = {
     # Architecture: (pattern, owner)
-    "PV64": ("amzn2-ami-pv*.x86_64-ebs", "amazon"),
-    "HVM64": ("amzn2-ami-hvm-*-x86_64-gp2", "amazon"),
-    "HVMG2": ("amzn2-ami-graphics-hvm-*x86_64-ebs*", "679593333241")
+    "HVM64": ("amzn2-ami-hvm-*-arm64-gp2", "amazon")
 }
 
 
@@ -220,7 +218,7 @@ def deploy_web_servers(event):
     webserver_parameters.append({'ParameterKey': 'WebLoadBalancerSG', 'ParameterValue': elb_sg, 'UsePreviousValue': True})
     webserver_parameters.append({'ParameterKey': 'WebLoadBalancerSubnets', 'ParameterValue': igw_subnets, 'UsePreviousValue': True})
     webserver_parameters.append({'ParameterKey': 'WebServerSubnets', 'ParameterValue': private_subnets, 'UsePreviousValue': True})
-    webserver_parameters.append({'ParameterKey': 'WebServerInstanceType', 'ParameterValue': 't2.micro', 'UsePreviousValue': True})
+    webserver_parameters.append({'ParameterKey': 'WebServerInstanceType', 'ParameterValue': 't4g.micro', 'UsePreviousValue': True})
     webserver_parameters.append({'ParameterKey': 'WebServerAMI', 'ParameterValue': latest_ami, 'UsePreviousValue': False})
     webserver_parameters.append({'ParameterKey': 'AvailabilityZones', 'ParameterValue': azs, 'UsePreviousValue': True})
     webserver_parameters.append({'ParameterKey': 'BootBucketRegion', 'ParameterValue': cfn_region, 'UsePreviousValue': True})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updated deprecated runtime for canary to the latest version
* To fix `urllib3 v2.0 only supports OpenSSL 1.1.1+, currently` error, downgrade urllib3 by adding `pip install urllib3==1.26.6` to user data
* Was seeing a problem `yum` installs and updates were taking too long. Previous executions, as well as patch management, were holding the `yum` lock. Updated instance type from t2.micro to t4g.micro (Graviton2) to speed up user data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
