### PR TITLE
chore: rename Lambda Powertools

### DIFF
--- a/content/Well-ArchitectedTool/300_Labs/300_Using_WAT_With_Cloudformation_And_Custom_Lambda/2_explore_lambda_code.md
+++ b/content/Well-ArchitectedTool/300_Labs/300_Using_WAT_With_Cloudformation_And_Custom_Lambda/2_explore_lambda_code.md
@@ -8,7 +8,7 @@ pre: "<b>2. </b>"
 ---
 
 ## Overview
-There are two AWS Lambda functions that you deployed in the previous step. Both of them utilize the [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) library along with the [Lambda Powertools Python](https://awslabs.github.io/aws-lambda-powertools-python/) via a Lambda layer to perform the [Well-Architected Tool API](https://docs.aws.amazon.com/wellarchitected/latest/APIReference/Welcome.html) access.
+There are two AWS Lambda functions that you deployed in the previous step. Both of them utilize the [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/) library along with the [Powertools for AWS Lambda (Python)](https://awslabs.github.io/aws-lambda-powertools-python/) via a Lambda layer to perform the [Well-Architected Tool API](https://docs.aws.amazon.com/wellarchitected/latest/APIReference/Welcome.html) access.
 
 ## Deployed AWS Lambda functions
 Click on each link to understand how each Lambda function works.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lambda Powertools is in the process of being renamed to Powertools for AWS Lambda. This PR updates your reference to the new name


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
