### PR TITLE
Clarity on the Role Prefix

### DIFF
--- a/content/Cost/300_Labs/300_Optimization_Data_Collection/1_Grant_permissions.md
+++ b/content/Cost/300_Labs/300_Optimization_Data_Collection/1_Grant_permissions.md
@@ -24,11 +24,13 @@ Some of the data needed for the modules is in the **Management account** we will
 
 3. In the Parameters section set **CostAccountID** as the ID of Data Collection Account ( where you plan to deploy the OptimizationDataCollectionStack)  
 
-4. Scroll to the bottom and click **Next**
+4. **NOTE** If you choose to modify the Role Prefix field, keep this consistent across all the Stacks and StackSets you create as part of this lab.
 
-5. Tick the acknowledge boxes and click **Create stack**.
+5. Scroll to the bottom and click **Next**
 
-6. You can see the role that was collected by clicking on **Resources** and clicking on the hyperlink under **Physical ID**.
+6. Tick the acknowledge boxes and click **Create stack**.
+
+7. You can see the role that was collected by clicking on **Resources** and clicking on the hyperlink under **Physical ID**.
 ![Images/Managment_CF_deployed.png](/Cost/300_Optimization_Data_Collection/Images/Managment_CF_deployed.png)
 
 
@@ -59,18 +61,20 @@ https://aws-well-architected-labs.s3-us-west-2.amazonaws.com/Cost/Labs/300_Optim
 
 ![Images/SS_param.png](/Cost/300_Optimization_Data_Collection/Images/SS_param.png)
 
-7. Leave all as default and Click **Next**.
+7. **NOTE** If you choose to modify the Role Prefix field, keep this consistent across all the Stacks and StackSets you create as part of this lab.
+
+8. Leave all as default and Click **Next**.
 
 ![Images/ods_stackset_config.png](/Cost/300_Optimization_Data_Collection/Images/ods_stackset_config.png)
 
-8. Select the **region** you are currently deploying to.
+9. Select the **region** you are currently deploying to.
 
 ![Images/ods_stackset_region.png](/Cost/300_Optimization_Data_Collection/Images/ods_stackset_region.png)
 
-9. Tick the boxes and click **Create stack**.
+10. Tick the boxes and click **Create stack**.
 ![Images/Tick_Box.png](/Cost/300_Optimization_Data_Collection/Images/Tick_Box.png)
 
-10. This role will now be deployed to all linked accounts. 
+11. This role will now be deployed to all linked accounts. 
 
 If you face an issue with `AWSCloudFormationStackSetAdministrationRole` please make sure you activated 'Tusted Access' (2nd step) or follow [AWS Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs-self-managed.html) for activating this via additional CloudFormation.
 
@@ -82,11 +86,11 @@ If you wish to also access data in your management account, deploy the same Clou
 
 1.  Log into your **Management account** then click [Launch CloudFormation Template](https://console.aws.amazon.com/cloudformation/home#/stacks/new?&templateURL=https://aws-well-architected-labs.s3-us-west-2.amazonaws.com/Cost/Labs/300_Optimization_Data_Collection/optimisation_read_only_role.yaml&stackName=OptimizationDataRoleStack)
 
-2. Call the Stack **OptimizationDataRoleStack**. In the Parameters section use the Cost Optimization Account ID that you deployed the OptimizationDataCollectionStack into for **CostAccountID**. Under available modules section select modules which you you selected in **OptimizationDataCollectionStack** deployment step. This CloudFormation StackSet will provision required roles for modules in linked accounts. Detailed description of each module can be found [here](../3_data_collection_modules)
+2. Call the Stack **OptimizationDataRoleStack**. In the Parameters section use the Cost Optimization Account ID that you deployed the OptimizationDataCollectionStack into for **CostAccountID**. Under available modules section select modules which you you selected in **OptimizationDataCollectionStack** deployment step. . **NOTE** If you choose to modify the Role Prefix field, keep this consistent across all the Stacks and StackSets you create as part of this lab. This CloudFormation StackSet will provision required roles for modules in linked accounts. Detailed description of each module can be found [here](../3_data_collection_modules)
 
-4. Scroll to the bottom and click **Next**
+3. Scroll to the bottom and click **Next**
 
-5. Tick the box **'I acknowledge that AWS CloudFormation might create IAM resources with custom names.'** and click **Create stack**.
+4. Tick the box **'I acknowledge that AWS CloudFormation might create IAM resources with custom names.'** and click **Create stack**.
 ![Images/Tick_Box.png](/Cost/300_Optimization_Data_Collection/Images/Tick_Box.png)
 
 

--- a/content/Cost/300_Labs/300_Optimization_Data_Collection/2_Deploy_Main_Resources.md
+++ b/content/Cost/300_Labs/300_Optimization_Data_Collection/2_Deploy_Main_Resources.md
@@ -19,7 +19,7 @@ Or if you wish to keep this on your local machine please copy [CloudFormation te
 ![Images/upload_templates3.png](/Cost/300_Optimization_Data_Collection/Images/upload_templates3.png)
 
 3. Call the stack **OptimizationDataCollectionStack** and fill Deployment parameters. The Role mentioned in **Multi Account Role Name** parameter will be deployed in the next step.
- Select the **Code bucket** for the region you are deploying in and fill **Management Account Id**. You have the option to change the name of your access roles, if you do please make the same changes in the **Role for Management Account** and the  **Read Only roles for Data Collector** deployments.
+ Select the **Code bucket** for the region you are deploying in and fill **Management Account Id**. You have the option to change the name of your prefix & access roles, **if you do** please make sure to use the same names used in the **Role for Management Account** and the  **Read Only roles for Data Collector** deployments.
  
  Under available modules section select modules which you would like to deploy. Detailed description of each module can be found [here](../3_data_collection_modules)
  Click **Next** and **Next again**

--- a/static/Cost/300_Optimization_Data_Collection/Code/Management.yaml
+++ b/static/Cost/300_Optimization_Data_Collection/Code/Management.yaml
@@ -6,11 +6,11 @@ Parameters:
     Description: AccountId of where the collector is deployed
   ManagementAccountRole:
     Type: String
-    Description: Name of role deployed into Management account to read high level data
+    Description: The name of the IAM role that will be deployed from the management account to linked accounts as a read only role. DO NOT ENTER THE ROLE PREFIX HERE. KEEP THE SAME AS WHAT IS DEPLOYED INTO MANAGEMENT ACCOUNT.
     Default: "Lambda-Assume-Role-Management-Account" 
   RolePrefix:
     Type: String
-    Description: This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable e.g. prefix-
+    Description: Keep this consistent with the prefix used for the Stacks and StackSets created as part of this lab. This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable e.g. prefix-
     Default: "WA-"
 Outputs:
   LambdaRole:

--- a/static/Cost/300_Optimization_Data_Collection/Code/Optimization_Data_Collector.yaml
+++ b/static/Cost/300_Optimization_Data_Collection/Code/Optimization_Data_Collector.yaml
@@ -40,7 +40,7 @@ Metadata:
       RolePrefix:
         default: "Role Prefix"
       CFNTemplateSourceBucket:
-        default: "DO NOT CHANGE - A bucket that contains WA-Labs CloudFormation templates. Must be allways 'aws-well-architected-labs'"
+        default: "DO NOT CHANGE - A bucket that contains WA-Labs CloudFormation templates. Must be 'aws-well-architected-labs'"
       IncludeTAModule:
         default: 'Include AWS Trusted Advisor Data Collection Module'
       IncludeRightsizingModule:
@@ -88,7 +88,7 @@ Parameters:
     Default: costoptimizationdata
   ManagementAccountRole:
     Type: String
-    Description: The name of the IAM role that will be deployed in the management account which can retrieve AWS Organization data. KEEP THE SAME AS WHAT IS DEPLOYED INTO MANAGEMENT ACCOUNT
+    Description: The name of the IAM role that will be deployed from the management account to linked accounts as a read only role. DO NOT ENTER THE ROLE PREFIX HERE. KEEP THE SAME AS WHAT IS DEPLOYED INTO MANAGEMENT ACCOUNT.
     Default: Lambda-Assume-Role-Management-Account
   ManagementAccountID:
     Type: String
@@ -96,7 +96,7 @@ Parameters:
     Description: "(Ex: 123456789,098654321,789054312) List of Payer IDs you wish to collect data for. Can just be one Accounts"
   MultiAccountRoleName:
     Type: String
-    Description: The name of the IAM role that will be deployed from the management account to linked accounts as a read only role. KEEP THE SAME AS WHAT IS DEPLOYED INTO MANAGEMENT ACCOUNT
+    Description: The name of the IAM role that will be deployed from the management account to linked accounts as a read only role. DO NOT ENTER THE ROLE PREFIX HERE. KEEP THE SAME AS WHAT IS DEPLOYED INTO MANAGEMENT ACCOUNT.
     Default: "Optimization-Data-Multi-Account-Role"
   Schedule:
     Type: String
@@ -104,11 +104,11 @@ Parameters:
     Default: "rate(14 days)"
   RolePrefix:
     Type: String
-    Description: This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable e.g. prefix-
+    Description: Keep this consistent with the prefix used for the Stacks and StackSets created as part of this lab. This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable e.g. prefix-
     Default: "WA-"
   CFNTemplateSourceBucket:
     Type: String
-    Description: "DO NOT CHANGE - A bucket that contains WA-Labs CloudFormation templates. Must be allways 'aws-well-architected-labs'"
+    Description: "DO NOT CHANGE - A bucket that contains WA-Labs CloudFormation templates. Must be 'aws-well-architected-labs'"
     Default: "aws-well-architected-labs"
   IncludeTAModule:
     Type: String

--- a/static/Cost/300_Optimization_Data_Collection/Code/optimisation_read_only_role.yaml
+++ b/static/Cost/300_Optimization_Data_Collection/Code/optimisation_read_only_role.yaml
@@ -46,11 +46,11 @@ Parameters:
     Description: AccountId of where the collector is deployed
   MultiAccountRoleName:
     Type: String
-    Description: The name of the IAM role that will be deployed from the management account to linked accounts as a read only role. KEEP THE SAME AS WHAT IS DEPLOYED INTO MANAGEMENT ACCOUNT
+    Description: The name of the IAM role that will be deployed from the management account to linked accounts as a read only role. DO NOT ENTER THE ROLE PREFIX HERE. KEEP THE SAME AS WHAT IS DEPLOYED INTO MANAGEMENT ACCOUNT.
     Default: "Optimization-Data-Multi-Account-Role"
   RolePrefix:
     Type: String
-    Description: This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable e.g. prefix-
+    Description: Keep this consistent with the prefix used for the Stacks and StackSets created as part of this lab. This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable e.g. prefix-
     Default: "WA-"
   IncludeTAModule:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Customers have been confused by what to enter as the Management Account Role and the Multi Account Role Name fields when they have changed this RolePrefix from the default (WA-). Added text to labs and CFN templates to help clarify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
