### PR TITLE
Block public and HTTP access for Compute Optimizer regional buckets

### DIFF
--- a/static/Cost/300_Optimization_Data_Collection/Code/module-compute-optimizer.yaml
+++ b/static/Cost/300_Optimization_Data_Collection/Code/module-compute-optimizer.yaml
@@ -194,6 +194,15 @@ Resources:
                           s3:x-amz-acl:  bucket-owner-full-control
                           aws:SourceAccount: !Split [',', !Ref ManagementAccountID]
                   Resource: !Sub "arn:aws:s3:::${Name}-${AWS::Region}/*"
+                - Effect: Deny
+                  Principal: "*"
+                  Action: s3:*
+                  Condition:
+                    Bool:
+                      aws:SecureTransport: 'false'
+                  Resource:
+                    - !Sub "arn:aws:s3:::${Name}-${AWS::Region}"
+                    - !Sub "arn:aws:s3:::${Name}-${AWS::Region}/*"
           ReplicaRole:
             Type: AWS::IAM::Role
             Properties:
@@ -262,6 +271,11 @@ Resources:
                     NoncurrentVersionExpiration:
                       NoncurrentDays: 1
                       NewerNoncurrentVersions: 1
+              PublicAccessBlockConfiguration:
+                BlockPublicAcls : true
+                BlockPublicPolicy : true
+                IgnorePublicAcls : true
+                RestrictPublicBuckets : true
   LambdaTriggerExportRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
*Issue #, if available:*
#940 

*Description of changes:*
- Implemented `PublicAccessBlockConfiguration` on Compute Optimizer regional buckets.
- Added Deny Action for non-HTTPS requests to Compute Optimizer regional buckets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
