### PR TITLE
Update 4_inventory_mgmt.md

### DIFF
--- a/content/Operational Excellence/100_Labs/100_Inventory_Patch_Management/4_inventory_mgmt.md
+++ b/content/Operational Excellence/100_Labs/100_Inventory_Patch_Management/4_inventory_mgmt.md
@@ -45,7 +45,7 @@ SSM Agent is installed by default on:
    1. In the **Choose the service that will use this role** section, scroll past the first reference to EC2 (**EC2 Allows EC2 instances to call AWS services on your behalf**) and choose **EC2** from within the field of services. This will open the **Select your use case** section further down the page.
    1. In the **Select your use case** section, choose **EC2 Role for AWS Systems Manager** to select it.
    1. Then choose **Next: Permissions**.
-1. Under **Attached permissions policy**, verify that **AmazonEC2RoleforSSM** is listed, and then choose **Next: Tags**.
+1. Under **Attached permissions policy**, verify that **AmazonSSMManagedInstanceCore** is listed, and then choose **Next: Tags**.
 1. In the **Tags** section:
    1. Add one or more **keys** and **values**, then choose **Next: Review**.
 1. In the **Review** section:


### PR DESCRIPTION
There is a change from AWS regarding the AWS Managed Role for EC2 SSM. The new role is "AmazonSSMManagedInstanceCore" instead of AmazonEC2RoleforSSM

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
