### PR TITLE
Adding a columns for Reservation owner Account

### DIFF
--- a/content/Cost/300_Labs/300_CUR_Queries/Queries/aws_cost_management.md
+++ b/content/Cost/300_Labs/300_CUR_Queries/Queries/aws_cost_management.md
@@ -133,7 +133,8 @@ Please refer to the relevant service reservation pricing page.
 ```tsql
 SELECT
   bill_payer_account_id,
-  line_item_usage_account_id,
+  line_item_usage_account_id AS "Usage Accccoud ID",
+  SPLIT_PART(reservation_reservation_a_r_n,':', 5) AS commitment_owner_accountID,
   DATE_FORMAT(line_item_usage_start_date,'%Y-%m') AS month_line_item_usage_start_date,
   line_item_product_code,
   reservation_reservation_a_r_n,
@@ -163,6 +164,7 @@ GROUP BY
   DATE_FORMAT(line_item_usage_start_date,'%Y-%m'),
   line_item_product_code,
   reservation_reservation_a_r_n,
+  SPLIT_PART(reservation_reservation_a_r_n,':', 5),
   SPLIT_PART(line_item_usage_type,':', 2),
   SPLIT_PART(reservation_reservation_a_r_n,':', 4)
 ORDER BY


### PR DESCRIPTION
Adding a column for reservation Owner Account Id information. This is useful for the situation when payer account ID, Reservation owner account ID and reservation usage account id's are all different. This is based on an ask that I helped my customer with where they wanted to see the usage of reservation based on who bought those RIs vs who used them.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
