### PR TITLE
Remove internal dashboard name from FAQ

### DIFF
--- a/content/Cost/200_Labs/200_Cloud_Intelligence/FAQ/_index.md
+++ b/content/Cost/200_Labs/200_Cloud_Intelligence/FAQ/_index.md
@@ -82,7 +82,7 @@ In order to create an analysis from any of the CUDOS Dashboards, Go edit the new
    1. Click “Share dashboard”
    1. Enable the "Allow "save as"" next to your username
    1. Click "Confirm"
-   1. Click the link in the top left corner to Go back to 'LazyMBR'
+   1. Click the link in the top left corner to Go back to 'CUDOS Dashboard' (or similar)
    1. You should now see a “Save as” (you might have to refresh browser)
    1. Click "Save as"
    1. Name your Analysis


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Remove internal dashboard name from CID FAQ doc and replace with relevant dashboard name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
