### PR TITLE
Correct SEC1 response wording

### DIFF
--- a/static/watool/300_Using_WAT_With_Cloudformation_And_Custom_Lambda/Code/CFN/SampleLambdaAPIGWDeploy.yaml
+++ b/static/watool/300_Using_WAT_With_Cloudformation_And_Custom_Lambda/Code/CFN/SampleLambdaAPIGWDeploy.yaml
@@ -115,8 +115,8 @@ Resources:
       QuestionAnswers:
         - "How do you securely operate your workload": # SEC1
           - "Separate workloads using accounts"
-          - "Secure AWS account"
-          - "Keep up to date with security threats"
+          - "Secure account root user and properties"
+          - "Keep up-to-date with security threats"
 
   RELWAWorkloadQuestions:
     # DependsOn: CreateWAWorkload


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The CloudFormation template for the sample APIGW app fails to deploy as responses provided for SEC1 don't align to the current WAFR response options.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
