### PR TITLE
Update 4_deploy_the_build_automation_with_SSM.md

### DIFF
--- a/content/Security/300_Labs/300_Autonomous_Patching_With_EC2_Image_Builder_and_Systems_Manager/4_deploy_the_build_automation_with_SSM.md
+++ b/content/Security/300_Labs/300_Autonomous_Patching_With_EC2_Image_Builder_and_Systems_Manager/4_deploy_the_build_automation_with_SSM.md
@@ -369,7 +369,7 @@ To Execute the automation document, you can run the following command:
 ```
 aws ssm start-automation-execution \
     --document-name "<enter_document_name>" \
-    --parameters "ApplicationStack=<enter_application_stack_name>,imageBuilderPipeline=<enter_image_builder_pipeline_arn>"
+    --parameters "ApplicationStack=<enter_application_stack_name>,ImageBuilderPipeline=<enter_image_builder_pipeline_arn>"
 
 ```
 


### PR DESCRIPTION
Correct parameter name: ImageBuilderPipeline

*Issue #, if available:*

Parameter name was wrong (was imageBuilderPipeline), , while running Automation via CLI it throws error

*Description of changes:*

Changed case to Uppercase for i, Correct parameter name: ImageBuilderPipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
