### PR TITLE
Update 4_deploy_the_build_automation_with_SSM.md

### DIFF
--- a/content/Security/300_Labs/300_Autonomous_Patching_With_EC2_Image_Builder_and_Systems_Manager/4_deploy_the_build_automation_with_SSM.md
+++ b/content/Security/300_Labs/300_Autonomous_Patching_With_EC2_Image_Builder_and_Systems_Manager/4_deploy_the_build_automation_with_SSM.md
@@ -74,7 +74,7 @@ The template for Section 4 which can be found [here](/Security/300_Autonomous_Pa
 To deploy the template from console please follow this [guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html) for information on how to deploy the cloudformation template. 
 
 * Use `pattern3-automate` as the **Stack Name**.
-* Provide the ARN of the pipeline you created in section **3.2.6** as **ImageBuilderPipelineARN** parameter value. 
+* Provide the cloudformation stack name you created in section **3.2.6** as **ImageBuilderPipelineStack** parameter value. 
 * Provide the cloudfromation stack name you created in section **2.1** as **ApplicationStack** parameter value. 
 
 ### 4.3. Record The CloudFormation Output.


### PR DESCRIPTION

*Issue #, if available:*

Instruction was wrong, instead of ImageBuilderPipeline ARN it would be CFN stack name.

*Description of changes:*

Rectified the instruction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
