### PR TITLE
updating Synthetics runtime Node.js version

### DIFF
--- a/static/Operations/200_Automating_operations_with_playbooks_and_runbooks/Code/templates/base_app.yml
+++ b/static/Operations/200_Automating_operations_with_playbooks_and_runbooks/Code/templates/base_app.yml
@@ -498,7 +498,7 @@ Resources:
             - ''
             - - s3://
               - Ref: ResultsBucket
-        RuntimeVersion: syn-nodejs-puppeteer-3.5
+        RuntimeVersion: syn-nodejs-puppeteer-6.2
         Schedule: 
           Expression: 'rate(1 minute)'
           DurationInSeconds: 0


### PR DESCRIPTION
Upgrading runtime version to resolve the error Unable to create a snapshot as the database instance is not in available state in the AWS Well-Architected Operational Excellence Workshop
