### PR TITLE
Update playbook_gather_resources.yml

### DIFF
--- a/static/Operations/200_Automating_operations_with_playbooks_and_runbooks/Code/templates/playbook_gather_resources.yml
+++ b/static/Operations/200_Automating_operations_with_playbooks_and_runbooks/Code/templates/playbook_gather_resources.yml
@@ -118,8 +118,8 @@ Resources:
                   # Search CloufFormation Stacks for tag
                   cfnclient = boto3.client('cloudformation', region_name = region )
                   list = cfnclient.list_stacks(StackStatusFilter=['CREATE_COMPLETE','ROLLBACK_COMPLETE','UPDATE_COMPLETE','UPDATE_ROLLBACK_COMPLETE','IMPORT_COMPLETE','IMPORT_ROLLBACK_COMPLETE']  )
+                  app_resources_list = []
                   for stack in list['StackSummaries']:
-                    app_resources_list = []
                     stack_name = stack['StackName']
                     stack_details = cfnclient.describe_stacks(StackName=stack_name)
                     stack_info = stack_details['Stacks'][0]
@@ -135,9 +135,8 @@ Resources:
                                 'Type': resource['ResourceType']
                               }
                             )
-                          result =  app_resources_list
+                  return app_resources_list
                   
-                  return result
                 def handler(event, context):
                   result = {}
                   arn = event['CloudWatchAlarmARN']


### PR DESCRIPTION
app_resources_list creation was inside of the loop logic which caused the values to reset each time a new stack was interrogated.  Depending on the order which the stacks were searched, the results may or may not have included the resources from the stack walab-ops-sample-application.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
